### PR TITLE
Set YARN NodeManager memory constraints to half the machine's total RAM

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/default.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/default.rb
@@ -16,6 +16,7 @@ default['hadoop']['yarn_site']['yarn.scheduler.minimum-allocation-mb'] = 512
 default['hadoop']['yarn_site']['yarn.nodemanager.vmem-check-enabled'] = 'false'
 default['hadoop']['yarn_site']['yarn.nodemanager.vmem-pmem-ratio'] = '5.1'
 default['hadoop']['yarn_site']['yarn.nodemanager.delete.debug-delay-sec'] = 86400
+default['hadoop']['yarn_site']['yarn.nodemanager.resource.memory-mb'] = (node[:memory][:total].to_i / 1024) / 2
 # Do the right thing, based on distribution
 case node['hadoop']['distribution']
 when 'cdh'


### PR DESCRIPTION
YARN NodeManager will try to use all of the available RAM on a system, even if it is allocated. Setting this option puts a sane upper bound on YARN memory usage.
