### PR TITLE
Add install action to base service

### DIFF
--- a/config/defaults/services/base.json
+++ b/config/defaults/services/base.json
@@ -5,6 +5,10 @@
   ],
   "provisioner": {
     "actions": {
+      "install": {
+        "type": "chef",
+        "script": "recipe[loom_base::default]"
+      },
       "configure": {
         "type": "chef",
         "script": "recipe[loom_base::default]"

--- a/examples/services/base.json
+++ b/examples/services/base.json
@@ -5,6 +5,10 @@
   ],
   "provisioner": {
     "actions": {
+      "install": {
+        "type": "chef",
+        "script": "recipe[loom_base::default]"
+      },
       "configure": {
         "type": "chef",
         "script": "recipe[loom_base::default]"


### PR DESCRIPTION
The base service may install packages, such as iptables, so it should have an install action.
