### PR TITLE
refactoring solver code to be more generic with the introduction

### DIFF
--- a/server/src/main/java/com/continuuity/loom/cluster/Node.java
+++ b/server/src/main/java/com/continuuity/loom/cluster/Node.java
@@ -158,6 +158,15 @@ public final class Node implements Comparable<Node> {
     return ImmutableList.copyOf((actions));
   }
 
+  /**
+   * Add a service to the node.
+   *
+   * @param service Service to add to the node.
+   */
+  public void addService(Service service) {
+    this.services.add(service);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/server/src/main/java/com/continuuity/loom/layout/NodeLayout.java
+++ b/server/src/main/java/com/continuuity/loom/layout/NodeLayout.java
@@ -16,8 +16,11 @@
 package com.continuuity.loom.layout;
 
 import com.continuuity.loom.admin.Constraints;
+import com.continuuity.loom.admin.Service;
 import com.continuuity.loom.admin.ServiceConstraint;
+import com.continuuity.loom.cluster.Node;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
 
@@ -106,9 +109,43 @@ public class NodeLayout {
     return true;
   }
 
+  /**
+   * Return the node layout of a given {@link Node}.
+   *
+   * @param node Node to derive the node layout from.
+   * @return Node layout of the node.
+   */
+  public static NodeLayout fromNode(Node node) {
+    String hardwareType = node.getProperties().get(Node.Properties.HARDWARETYPE.name().toLowerCase()).getAsString();
+    String imageType = node.getProperties().get(Node.Properties.IMAGETYPE.name().toLowerCase()).getAsString();
+    Set<String> services = Sets.newHashSet();
+    for (Service service : node.getServices()) {
+      services.add(service.getName());
+    }
+    return new NodeLayout(hardwareType, imageType, services);
+  }
+
+  /**
+   * Create a new NodeLayout by adding a service to the given NodeLayout.
+   *
+   * @param nodeLayout NodeLayout to add the service to.
+   * @param service Service to add.
+   * @return New layout obtained by adding the service to the given layout.
+   */
   public static NodeLayout addServiceToNodeLayout(NodeLayout nodeLayout, String service) {
+    return addServicesToNodeLayout(nodeLayout, ImmutableSet.of(service));
+  }
+
+  /**
+   * Create a new NodeLayout by adding a set of services to the given NodeLayout.
+   *
+   * @param nodeLayout NodeLayout to add the services to.
+   * @param services Services to add.
+   * @return New layout obtained by adding the services to the given layout.
+   */
+  public static NodeLayout addServicesToNodeLayout(NodeLayout nodeLayout, Set<String> services) {
     Set<String> expandedServices = Sets.newTreeSet(nodeLayout.getServiceNames());
-    expandedServices.add(service);
+    expandedServices.addAll(services);
     return new NodeLayout(nodeLayout.hardwareType, nodeLayout.imageType, expandedServices);
   }
 
@@ -126,5 +163,14 @@ public class NodeLayout {
   @Override
   public int hashCode() {
     return Objects.hashCode(services, hardwareType, imageType);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("hardwareType", hardwareType)
+      .add("imageType", imageType)
+      .add("services", services)
+      .toString();
   }
 }

--- a/server/src/main/java/com/continuuity/loom/layout/Solver.java
+++ b/server/src/main/java/com/continuuity/loom/layout/Solver.java
@@ -22,6 +22,8 @@ import com.continuuity.loom.admin.Provider;
 import com.continuuity.loom.admin.Service;
 import com.continuuity.loom.cluster.Cluster;
 import com.continuuity.loom.cluster.Node;
+import com.continuuity.loom.layout.change.ClusterLayoutChange;
+import com.continuuity.loom.layout.change.ClusterLayoutTracker;
 import com.continuuity.loom.scheduler.task.NodeService;
 import com.continuuity.loom.store.EntityStore;
 import com.google.common.base.Joiner;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
@@ -56,8 +59,9 @@ public class Solver {
     this.updater = updater;
   }
 
-  public ClusterLayout addServiceToCluster(String clusterId, Set<String> servicesToAdd) throws Exception {
-    return updater.addServicesToCluster(clusterId, servicesToAdd);
+  public Queue<ClusterLayoutChange> addServiceToCluster(String clusterId, Set<String> servicesToAdd) throws Exception {
+    ClusterLayoutTracker tracker = updater.addServicesToCluster(clusterId, servicesToAdd);
+    return tracker == null ? null : tracker.getChanges();
   }
 
   /**

--- a/server/src/main/java/com/continuuity/loom/layout/change/AddServiceChangeIterator.java
+++ b/server/src/main/java/com/continuuity/loom/layout/change/AddServiceChangeIterator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.admin.ServiceConstraint;
+import com.continuuity.loom.layout.ClusterLayout;
+import com.continuuity.loom.layout.NodeLayout;
+import com.continuuity.loom.layout.NodeLayoutComparator;
+import com.continuuity.loom.layout.SlottedCombinationIterator;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Sets;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Return all the ways in which the given cluster layout can be expanded by adding the given service to one or more
+ * nodes in the cluster layout.
+ */
+public class AddServiceChangeIterator implements Iterator<ClusterLayoutChange> {
+  private final String service;
+  private final List<NodeLayout> expandableNodeLayouts;
+  private Iterator<int[]> nodeLayoutCountIterator;
+  private int[] nodeLayoutMaxCounts;
+  private int nodesToAddTo;
+  private int minNodesToAddTo;
+
+  public AddServiceChangeIterator(ClusterLayout clusterLayout, String service) {
+    this.service = service;
+    // cluster services are needed in order to prune the constraints to only use ones that pertain to services
+    // on the cluster
+    Set<String> expandedClusterServices = Sets.newHashSet(service);
+    for (NodeLayout nodeLayout : clusterLayout.getLayout().elementSet()) {
+      expandedClusterServices.addAll(nodeLayout.getServiceNames());
+    }
+    // first figure out which node layouts can add this service
+    this.expandableNodeLayouts = Lists.newArrayListWithCapacity(clusterLayout.getLayout().elementSet().size());
+    Multiset<NodeLayout> expandedCounts = HashMultiset.create();
+    for (NodeLayout originalNodeLayout : clusterLayout.getLayout().elementSet()) {
+      NodeLayout expandedNodeLayout = NodeLayout.addServiceToNodeLayout(originalNodeLayout, service);
+      if (expandedNodeLayout.satisfiesConstraints(clusterLayout.getConstraints(), expandedClusterServices)) {
+        expandableNodeLayouts.add(originalNodeLayout);
+        expandedCounts.add(originalNodeLayout, clusterLayout.getLayout().count(originalNodeLayout));
+      }
+    }
+    // sort expandable node layouts by preference order
+    Collections.sort(this.expandableNodeLayouts, new NodeLayoutComparator(null, null));
+    // need to pass this to the slotted iterator so we don't try and add the service to a node layout more times
+    // than there are nodes for the node layout.
+    this.nodeLayoutMaxCounts = new int[expandableNodeLayouts.size()];
+    for (int i = 0; i < nodeLayoutMaxCounts.length; i++) {
+      nodeLayoutMaxCounts[i] = expandedCounts.count(expandableNodeLayouts.get(i));
+    }
+    // figure out the max number of nodes we can add the service to. Start off by saying we can add it to all nodes.
+    this.nodesToAddTo = expandedCounts.size();
+    // we always need to add the service to at least one node.
+    this.minNodesToAddTo = 1;
+    ServiceConstraint serviceConstraint = clusterLayout.getConstraints().getServiceConstraints().get(service);
+    // if there is a max constraint on this service and its less than the number of nodes in the cluster, start
+    // there instead. Similarly, if there is a min constraint on this service higher than 1, use that instead.
+    if (serviceConstraint != null) {
+      this.nodesToAddTo = Math.min(serviceConstraint.getMaxCount(), this.nodesToAddTo);
+      this.minNodesToAddTo = Math.max(serviceConstraint.getMinCount(), this.minNodesToAddTo);
+    }
+    this.nodeLayoutCountIterator = (this.nodesToAddTo < 1) ? null :
+      new SlottedCombinationIterator(expandableNodeLayouts.size(), nodesToAddTo, nodeLayoutMaxCounts);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (nodeLayoutCountIterator == null) {
+      return false;
+    }
+    // run out of possibilities with this iterator, reduce the number of nodes we're adding the service to
+    // and look for more possibilites.
+    while (!nodeLayoutCountIterator.hasNext()) {
+      nodesToAddTo--;
+      if (nodesToAddTo < minNodesToAddTo) {
+        return false;
+      } else {
+        nodeLayoutCountIterator =
+          new SlottedCombinationIterator(expandableNodeLayouts.size(), nodesToAddTo, nodeLayoutMaxCounts);
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public ClusterLayoutChange next() {
+    if (hasNext()) {
+      int[] nodeLayoutCounts = nodeLayoutCountIterator.next();
+      // create the change object from the integer array
+      Multiset<NodeLayout> counts = HashMultiset.create();
+      for (int i = 0; i < nodeLayoutCounts.length; i++) {
+        counts.add(expandableNodeLayouts.get(i), nodeLayoutCounts[i]);
+      }
+      return new AddServicesChange(counts, service);
+    }
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/server/src/main/java/com/continuuity/loom/layout/change/AddServicesChange.java
+++ b/server/src/main/java/com/continuuity/loom/layout/change/AddServicesChange.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.admin.Service;
+import com.continuuity.loom.cluster.Cluster;
+import com.continuuity.loom.cluster.Node;
+import com.continuuity.loom.layout.ClusterLayout;
+import com.continuuity.loom.layout.NodeLayout;
+import com.google.common.base.Objects;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Sets;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adds services to specified number of nodes of given nodelayouts in a cluster.
+ */
+public class AddServicesChange implements ClusterLayoutChange {
+  private final Set<String> services;
+  private final Multiset<NodeLayout> countsPerNodeLayout;
+
+  public AddServicesChange(Multiset<NodeLayout> countsPerNodeLayout, String service) {
+    this(countsPerNodeLayout, ImmutableSet.of(service));
+  }
+
+  public AddServicesChange(Multiset<NodeLayout> countsPerNodeLayout, Set<String> services) {
+    this.services = ImmutableSet.copyOf(services);
+    this.countsPerNodeLayout = HashMultiset.create(countsPerNodeLayout);
+  }
+
+  @Override
+  public boolean canApplyChange(ClusterLayout layout) {
+    // check that all node layouts we need to add the service to exist in the given cluster layout
+    if (layout == null || !layout.getLayout().containsAll(countsPerNodeLayout.elementSet())) {
+      return false;
+    }
+    // check that if we need to add the service to 5 nodes with node layout XYZ, that there are at least 5 nodes in the
+    // cluster with node layout XYZ.
+    for (Multiset.Entry<NodeLayout> entry : countsPerNodeLayout.entrySet()) {
+      if (layout.getLayout().count(entry.getElement()) < entry.getCount()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public ClusterLayout applyChange(ClusterLayout originalLayout) {
+    Multiset<NodeLayout> newLayout = HashMultiset.create(originalLayout.getLayout());
+    for (Multiset.Entry<NodeLayout> entry : countsPerNodeLayout.entrySet()) {
+      NodeLayout originalNodeLayout = entry.getElement();
+      NodeLayout expandedNodeLayout = NodeLayout.addServicesToNodeLayout(originalNodeLayout, services);
+      // add the service count times
+      newLayout.add(expandedNodeLayout, entry.getCount());
+      // subtract count nodes from the original node layout since that many have now been expanded.
+      newLayout.setCount(originalNodeLayout, originalLayout.getLayout().count(originalNodeLayout) - entry.getCount());
+    }
+    return new ClusterLayout(originalLayout.getConstraints(), newLayout);
+  }
+
+  @Override
+  public void applyChange(Cluster cluster, Set<Node> clusterNodes, Map<String, Service> serviceMap) {
+    Multiset<NodeLayout> countsToAdd = HashMultiset.create(countsPerNodeLayout);
+    for (Node node : clusterNodes) {
+      NodeLayout nodeLayout = NodeLayout.fromNode(node);
+      if (countsToAdd.contains(nodeLayout)) {
+        for (String service : services) {
+          node.addService(serviceMap.get(service));
+        }
+        countsToAdd.setCount(nodeLayout, countsToAdd.count(nodeLayout) - 1);
+      }
+    }
+    cluster.setServices(Sets.union(cluster.getServices(), services));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AddServicesChange)) {
+      return false;
+    }
+
+    AddServicesChange that = (AddServicesChange) o;
+
+    return Objects.equal(countsPerNodeLayout, that.countsPerNodeLayout) &&
+      Objects.equal(services, that.services);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(services, countsPerNodeLayout);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("services", services)
+      .add("countsPerNodeLayout", countsPerNodeLayout)
+      .toString();
+  }
+}

--- a/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutChange.java
+++ b/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutChange.java
@@ -18,7 +18,10 @@ import java.util.Set;
 public interface ClusterLayoutChange {
 
   /**
-   * Returns whether or not the change can be applied to the given {@link ClusterLayout}.
+   * Returns whether or not the change can be applied to the given {@link ClusterLayout}. This is not for checking
+   * if the resulting cluster layout would satisfy all its constraints, but for checking whether or not it is physically
+   * possible to apply the change. For example, it is not physically possible to add a service to 10 nodes if the
+   * cluster is only 5 nodes.
    *
    * @param layout Layout to check the legality of the change for.
    * @return True if the change can be applied, false if not.

--- a/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutChange.java
+++ b/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutChange.java
@@ -1,0 +1,46 @@
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.admin.Service;
+import com.continuuity.loom.cluster.Cluster;
+import com.continuuity.loom.cluster.Node;
+import com.continuuity.loom.layout.ClusterLayout;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents some change to a {@link ClusterLayout}, such as adding a service to some of the nodes. Caller is
+ * responsible for calling the {@link #canApplyChange(com.continuuity.loom.layout.ClusterLayout)} method to validate
+ * if a change can be applied to a layout before actually applying the change with
+ * {@link #applyChange(com.continuuity.loom.layout.ClusterLayout)} or
+ * {@link #applyChange(com.continuuity.loom.cluster.Cluster, java.util.Set, java.util.Map)}.
+ */
+public interface ClusterLayoutChange {
+
+  /**
+   * Returns whether or not the change can be applied to the given {@link ClusterLayout}.
+   *
+   * @param layout Layout to check the legality of the change for.
+   * @return True if the change can be applied, false if not.
+   */
+  boolean canApplyChange(ClusterLayout layout);
+
+  /**
+   * Apply the change to the given {@link ClusterLayout}. Returns a new layout object and does not modify the given
+   * layout.
+   *
+   * @param layout Layout to apply the change to.
+   * @return New layout object after the change.
+   */
+  ClusterLayout applyChange(ClusterLayout layout);
+
+  /**
+   * Apply the change to a set of nodes.
+   *
+   * @param cluster Cluster to apply the change to.
+   * @param clusterNodes Nodes to apply the change to.
+   * @param serviceMap Map of service name to {@link Service} for available services.
+   * TODO: remove the need for the serviceMap
+   */
+  void applyChange(Cluster cluster, Set<Node> clusterNodes, Map<String, Service> serviceMap);
+}

--- a/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutTracker.java
+++ b/server/src/main/java/com/continuuity/loom/layout/change/ClusterLayoutTracker.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.layout.ClusterLayout;
+import com.google.common.collect.Lists;
+
+import java.util.Deque;
+import java.util.Queue;
+
+/**
+ * Helper for keeping track of changes made to a {@link com.continuuity.loom.layout.ClusterLayout}.
+ */
+public class ClusterLayoutTracker {
+  private final Deque<ClusterLayoutChange> changes;
+  private final Deque<ClusterLayout> states;
+
+  /**
+   * Create a layout change tracker given some starting layout.
+   *
+   * @param startingLayout starting layout of the cluster.
+   */
+  public ClusterLayoutTracker(ClusterLayout startingLayout) {
+    this.changes = Lists.newLinkedList();
+    this.states = Lists.newLinkedList();
+    this.states.add(startingLayout);
+  }
+
+  /**
+   * Adds a change to the layout if the change can be applied to the current layout, returning whether or not
+   * the change was added.
+   *
+   * @param change Change to add, assuming it can be applied to the current layout.
+   * @return True if the change was added, false if not.
+   */
+  public boolean addChangeIfValid(ClusterLayoutChange change) {
+    ClusterLayout currentLayout = getCurrentLayout();
+    if (change.canApplyChange(currentLayout)) {
+      changes.addLast(change);
+      states.addLast(change.applyChange(currentLayout));
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Remove the last change performed on the cluster layout.
+   */
+  public void removeLastChange() {
+    changes.removeLast();
+    states.removeLast();
+  }
+
+  /**
+   * Get the current layout of the cluster.
+   *
+   * @return Current layout of the cluster.
+   */
+  public ClusterLayout getCurrentLayout() {
+    return states.getLast();
+  }
+
+  /**
+   * Get the changes that were applied to the starting cluster layout.
+   *
+   * @return Changes that were applied to the starting cluster layout.
+   */
+  public Queue<ClusterLayoutChange> getChanges() {
+    return changes;
+  }
+}

--- a/server/src/test/java/com/continuuity/loom/layout/BaseSolverTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/BaseSolverTest.java
@@ -34,6 +34,7 @@ import com.continuuity.loom.codec.json.JsonSerde;
 import com.continuuity.utils.ImmutablePair;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import org.junit.BeforeClass;
 
 import java.util.Map;
@@ -54,6 +55,7 @@ public class BaseSolverTest extends BaseTest {
   protected static Service zookeeper;
   protected static Service reactor;
   protected static Service mysql;
+  protected static Map<String, Service> serviceMap;
 
   @BeforeClass
   public static void setupBaseSolverTests() throws Exception {
@@ -170,6 +172,16 @@ public class BaseSolverTest extends BaseTest {
     reactor = new Service("reactor", "", ImmutableSet.<String>of("zookeeper", "regionserver", "nodemanager"),
                           ImmutableMap.<ProvisionerAction, ServiceAction>of());
     mysql = new Service("mysql", "", ImmutableSet.<String>of(), ImmutableMap.<ProvisionerAction, ServiceAction>of());
+    serviceMap = Maps.newHashMap();
+    serviceMap.put(namenode.getName(), namenode);
+    serviceMap.put(datanode.getName(), datanode);
+    serviceMap.put(resourcemanager.getName(), resourcemanager);
+    serviceMap.put(nodemanager.getName(), nodemanager);
+    serviceMap.put(hbasemaster.getName(), hbasemaster);
+    serviceMap.put(regionserver.getName(), regionserver);
+    serviceMap.put(zookeeper.getName(), zookeeper);
+    serviceMap.put(reactor.getName(), reactor);
+    serviceMap.put(mysql.getName(), mysql);
 
     entityStore.writeService(namenode);
     entityStore.writeService(datanode);

--- a/server/src/test/java/com/continuuity/loom/layout/ClusterLayoutTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/ClusterLayoutTest.java
@@ -36,62 +36,6 @@ public class ClusterLayoutTest {
   private static Constraints constraints;
 
   @Test
-  public void testExpandClusterLayout() {
-    NodeLayout masterNodeLayout = new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode"));
-    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("datanode"));
-    Multiset<NodeLayout> counts = HashMultiset.create();
-    counts.add(masterNodeLayout);
-    counts.add(slaveLayout, 50);
-    ClusterLayout layout = new ClusterLayout(constraints, counts);
-
-    NodeLayout expandedMasterNodeLayout =
-      new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode", "resourcemanager"));
-    NodeLayout expandedSlaveNodeLayout =
-      new NodeLayout("medium", "centos6", ImmutableSet.of("datanode", "nodemanager"));
-
-    // add resourcemanager to master node
-    Multiset<NodeLayout> addCounts = HashMultiset.create();
-    addCounts.add(masterNodeLayout, 1);
-    ClusterLayout expanded = ClusterLayout.expandClusterLayout(layout, "resourcemanager", addCounts);
-    Multiset<NodeLayout> expectedCounts = HashMultiset.create();
-    expectedCounts.add(expandedMasterNodeLayout, 1);
-    expectedCounts.add(slaveLayout, 50);
-    ClusterLayout expected = new ClusterLayout(constraints, expectedCounts);
-    Assert.assertEquals(expected, expanded);
-
-    // add nodemanager to half of the slave nodes
-    addCounts = HashMultiset.create();
-    addCounts.add(slaveLayout, 25);
-    expanded = ClusterLayout.expandClusterLayout(expanded, "nodemanager", addCounts);
-    expectedCounts = HashMultiset.create();
-    expectedCounts.add(expandedMasterNodeLayout, 1);
-    expectedCounts.add(slaveLayout, 25);
-    expectedCounts.add(expandedSlaveNodeLayout, 25);
-    expected = new ClusterLayout(constraints, expectedCounts);
-    Assert.assertEquals(expected, expanded);
-
-    // add nodemanager to the rest of the slave nodes
-    expanded = ClusterLayout.expandClusterLayout(expanded, "nodemanager", addCounts);
-    expectedCounts = HashMultiset.create();
-    expectedCounts.add(expandedMasterNodeLayout, 1);
-    expectedCounts.add(expandedSlaveNodeLayout, 50);
-    expected = new ClusterLayout(constraints, expectedCounts);
-    Assert.assertEquals(expected, expanded);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidNodeLayoutsThrowsException() {
-    NodeLayout masterNodeLayout = new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode"));
-    Multiset<NodeLayout> counts = HashMultiset.create();
-    counts.add(masterNodeLayout);
-    NodeLayout badNodeLayout = new NodeLayout("large-mem", "ubuntu12", ImmutableSet.of("namenode"));
-    Multiset badCounts = HashMultiset.create();
-    badCounts.add(badNodeLayout);
-    ClusterLayout layout = new ClusterLayout(constraints, counts);
-    ClusterLayout.expandClusterLayout(layout, "resourcemanager", badCounts);
-  }
-
-  @Test
   public void testInvalidHardwareTypeShowsAsInvalid() {
     NodeLayout badNodeLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("namenode"));
     Multiset<NodeLayout> counts = HashMultiset.create();

--- a/server/src/test/java/com/continuuity/loom/layout/ClusterLayoutUpdaterTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/ClusterLayoutUpdaterTest.java
@@ -48,7 +48,8 @@ public class ClusterLayoutUpdaterTest extends BaseSolverTest {
     expectedCounts.add(slaveNodeLayout, 50);
     ClusterLayout expected = new ClusterLayout(reactorTemplate.getConstraints(), expectedCounts);
 
-    ClusterLayout layout = updater.addServicesToCluster(clusterId, ImmutableSet.of(resourcemanager.getName()));
+    ClusterLayout layout =
+      updater.addServicesToCluster(clusterId, ImmutableSet.of(resourcemanager.getName())).getCurrentLayout();
     Assert.assertEquals(expected, layout);
   }
 
@@ -66,9 +67,9 @@ public class ClusterLayoutUpdaterTest extends BaseSolverTest {
     expectedCounts.add(slaveNodeLayout, 50);
     ClusterLayout expected = new ClusterLayout(reactorTemplate.getConstraints(), expectedCounts);
 
-    ClusterLayout layout =
-      updater.addServicesToCluster(clusterId, ImmutableSet.of(resourcemanager.getName(), nodemanager.getName(),
-                                                              hbasemaster.getName(), regionserver.getName()));
+    ClusterLayout layout = updater.addServicesToCluster(
+      clusterId, ImmutableSet.of(resourcemanager.getName(), nodemanager.getName(),
+                                 hbasemaster.getName(), regionserver.getName())).getCurrentLayout();
     Assert.assertEquals(expected, layout);
   }
 

--- a/server/src/test/java/com/continuuity/loom/layout/change/AddServiceChangeIteratorTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/change/AddServiceChangeIteratorTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.admin.Constraints;
+import com.continuuity.loom.admin.LayoutConstraint;
+import com.continuuity.loom.admin.ServiceConstraint;
+import com.continuuity.loom.layout.ClusterLayout;
+import com.continuuity.loom.layout.NodeLayout;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ *
+ */
+public class AddServiceChangeIteratorTest {
+  private static Constraints constraints;
+
+  @Test
+  public void testSimpleIterator() {
+    NodeLayout masterNodeLayout = new NodeLayout("large", "centos6", ImmutableSet.of("master1"));
+    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("slave1"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(slaveLayout);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+    Iterator<ClusterLayoutChange> iter = new AddServiceChangeIterator(layout, "slave2");
+
+    // only possible change is to add slave2 to the slave node
+    List<ClusterLayoutChange> expected = Lists.newArrayList();
+    Multiset<NodeLayout> expectedCounts = HashMultiset.create();
+    expectedCounts.add(slaveLayout);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+
+    assertIterator(expected, iter);
+  }
+
+  @Test
+  public void testMultiSlaveNodeIterator() {
+    NodeLayout masterNodeLayout = new NodeLayout("large", "centos6", ImmutableSet.of("master1"));
+    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("slave1"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(slaveLayout, 5);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+    Iterator<ClusterLayoutChange> iter = new AddServiceChangeIterator(layout, "slave2");
+
+    // should try to add service to 5 slave nodes, then 4, then 3, then 2, then 1.
+    List<ClusterLayoutChange> expected = Lists.newArrayList();
+    Multiset<NodeLayout> expectedCounts = HashMultiset.create();
+    expectedCounts.setCount(slaveLayout, 5);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+    expectedCounts.setCount(slaveLayout, 4);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+    expectedCounts.setCount(slaveLayout, 3);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+    expectedCounts.setCount(slaveLayout, 2);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+    expectedCounts.setCount(slaveLayout, 1);
+    expected.add(new AddServicesChange(expectedCounts, "slave2"));
+
+    assertIterator(expected, iter);
+  }
+
+  @Test
+  public void testMultiNodeIterator() {
+    NodeLayout masterNodeLayout = new NodeLayout("large", "centos6", ImmutableSet.of("master1"));
+    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("slave1", "slave2"));
+    NodeLayout appLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("app"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(slaveLayout, 3);
+    counts.add(appLayout, 2);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+    Iterator<ClusterLayoutChange> iter = new AddServiceChangeIterator(layout, "base");
+
+    // slave, master, app
+    List<ClusterLayoutChange> expected = Lists.newArrayList();
+    // add base to 6 nodes:
+    // 3, 1, 2
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 1, appLayout, 2);
+    // add base to 5 nodes:
+    // 3, 1, 1
+    // 3, 0, 2
+    // 2, 1, 2
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 1, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 0, appLayout, 2);
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 1, appLayout, 2);
+    // add base to 4 nodes:
+    // 3, 1, 0
+    // 3, 0, 1
+    // 2, 1, 1
+    // 2, 0, 2
+    // 1, 1, 2
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 1, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 0, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 1, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 0, appLayout, 2);
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 1, appLayout, 2);
+    // add base to 3 nodes:
+    // 3, 0, 0
+    // 2, 1, 0
+    // 2, 0, 1
+    // 1, 1, 1
+    // 1, 0, 2
+    // 0, 1, 2
+    addExpected(expected, "base", slaveLayout, 3, masterNodeLayout, 0, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 1, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 0, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 1, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 0, appLayout, 2);
+    addExpected(expected, "base", slaveLayout, 0, masterNodeLayout, 1, appLayout, 2);
+    // add base to 2 nodes:
+    // 2, 0, 0
+    // 1, 1, 0
+    // 1, 0, 1
+    // 0, 1, 1
+    // 0, 0, 2
+    addExpected(expected, "base", slaveLayout, 2, masterNodeLayout, 0, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 1, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 0, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 0, masterNodeLayout, 1, appLayout, 1);
+    addExpected(expected, "base", slaveLayout, 0, masterNodeLayout, 0, appLayout, 2);
+    // add base to 1 node:
+    // 1, 0, 0
+    // 0, 1, 0
+    // 0, 0, 1
+    addExpected(expected, "base", slaveLayout, 1, masterNodeLayout, 0, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 0, masterNodeLayout, 1, appLayout, 0);
+    addExpected(expected, "base", slaveLayout, 0, masterNodeLayout, 0, appLayout, 1);
+
+    assertIterator(expected, iter);
+  }
+
+  private void addExpected(List<ClusterLayoutChange> expected, String service, NodeLayout nodeLayout1, int count1,
+                           NodeLayout nodeLayout2, int count2, NodeLayout nodeLayout3, int count3) {
+    Multiset<NodeLayout> expectedCounts = HashMultiset.create();
+    expectedCounts.setCount(nodeLayout1, count1);
+    expectedCounts.setCount(nodeLayout2, count2);
+    expectedCounts.setCount(nodeLayout3, count3);
+    expected.add(new AddServicesChange(expectedCounts, service));
+
+  }
+
+  private <T> void assertIterator(List<T> expected, Iterator<T> iter) {
+    while (iter.hasNext()) {
+      Assert.assertEquals(expected.remove(0), iter.next());
+    }
+    Assert.assertEquals(0, expected.size());
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    constraints = new Constraints(
+      ImmutableMap.<String, ServiceConstraint>of(
+        "master1",
+        new ServiceConstraint(
+          ImmutableSet.of("large"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 1, 1, null),
+        "slave1",
+        new ServiceConstraint(
+          ImmutableSet.of("medium"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null),
+        "slave2",
+        new ServiceConstraint(
+          ImmutableSet.of("medium"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null),
+        "base",
+        new ServiceConstraint(
+          null,
+          ImmutableSet.of("centos6", "ubuntu12"), 0, 50, 1, null),
+        "app",
+        new ServiceConstraint(
+          ImmutableSet.of("medium"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null)
+      ),
+      new LayoutConstraint(
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("slave1", "slave2")
+        ),
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("master1", "slave1"),
+          ImmutableSet.of("master1", "slave2")
+        )
+      )
+    );
+  }
+}

--- a/server/src/test/java/com/continuuity/loom/layout/change/AddServicesChangeTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/change/AddServicesChangeTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.Entities;
+import com.continuuity.loom.admin.Constraints;
+import com.continuuity.loom.admin.LayoutConstraint;
+import com.continuuity.loom.admin.ServiceConstraint;
+import com.continuuity.loom.cluster.Cluster;
+import com.continuuity.loom.cluster.Node;
+import com.continuuity.loom.layout.BaseSolverTest;
+import com.continuuity.loom.layout.ClusterLayout;
+import com.continuuity.loom.layout.NodeLayout;
+import com.continuuity.utils.ImmutablePair;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class AddServicesChangeTest extends BaseSolverTest {
+  private static Constraints constraints;
+
+  @Test
+  public void testApplyChangeToClusterLayout() {
+    NodeLayout masterNodeLayout = new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode"));
+    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("datanode"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(slaveLayout, 50);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+
+    NodeLayout expandedMasterNodeLayout =
+      new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode", "resourcemanager"));
+    NodeLayout expandedSlaveNodeLayout =
+      new NodeLayout("medium", "centos6", ImmutableSet.of("datanode", "nodemanager"));
+
+    // add resourcemanager to master node
+    Multiset<NodeLayout> addCounts = HashMultiset.create();
+    addCounts.add(masterNodeLayout, 1);
+    AddServicesChange change = new AddServicesChange(addCounts, "resourcemanager");
+    ClusterLayout expanded = change.applyChange(layout);
+    Multiset<NodeLayout> expectedCounts = HashMultiset.create();
+    expectedCounts.add(expandedMasterNodeLayout, 1);
+    expectedCounts.add(slaveLayout, 50);
+    ClusterLayout expected = new ClusterLayout(constraints, expectedCounts);
+    Assert.assertEquals(expected, expanded);
+
+    // add nodemanager to half of the slave nodes
+    addCounts = HashMultiset.create();
+    addCounts.add(slaveLayout, 25);
+    change = new AddServicesChange(addCounts, "nodemanager");
+    expanded = change.applyChange(expanded);
+    expectedCounts = HashMultiset.create();
+    expectedCounts.add(expandedMasterNodeLayout, 1);
+    expectedCounts.add(slaveLayout, 25);
+    expectedCounts.add(expandedSlaveNodeLayout, 25);
+    expected = new ClusterLayout(constraints, expectedCounts);
+    Assert.assertEquals(expected, expanded);
+
+    // add nodemanager to the rest of the slave nodes
+    expanded = change.applyChange(expanded);
+    expectedCounts = HashMultiset.create();
+    expectedCounts.add(expandedMasterNodeLayout, 1);
+    expectedCounts.add(expandedSlaveNodeLayout, 50);
+    expected = new ClusterLayout(constraints, expectedCounts);
+    Assert.assertEquals(expected, expanded);
+  }
+
+  @Test
+  public void testInvalidNodeLayouts() {
+    NodeLayout masterNodeLayout = new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    NodeLayout badNodeLayout = new NodeLayout("large-mem", "ubuntu12", ImmutableSet.of("namenode"));
+    Multiset badCounts = HashMultiset.create();
+    badCounts.add(badNodeLayout);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+    AddServicesChange change = new AddServicesChange(badCounts, "resourcemanager");
+    Assert.assertFalse(change.canApplyChange(layout));
+  }
+
+  @Test
+  public void testApplyChangeToCluster() {
+    String clusterId = "123";
+    Set<String> nodeIds = Sets.newHashSet();
+    Set<Node> nodes = Sets.newHashSet();
+    // hadoop master node
+    Node node = new Node(UUID.randomUUID().toString(), clusterId,
+                         ImmutableSet.of(namenode),
+                         ImmutableMap.<String, String>of(
+                           Node.Properties.HARDWARETYPE.name().toLowerCase(), "large-mem",
+                           Node.Properties.IMAGETYPE.name().toLowerCase(), "centos6"));
+    nodeIds.add(node.getId());
+    nodes.add(node);
+    // slave nodes
+    for (int i = 0; i < 50; i++) {
+      node = new Node(UUID.randomUUID().toString(), clusterId, ImmutableSet.of(datanode),
+                      ImmutableMap.<String, String>of(
+                        Node.Properties.HARDWARETYPE.name().toLowerCase(), "medium",
+                        Node.Properties.IMAGETYPE.name().toLowerCase(), "centos6"));
+      nodeIds.add(node.getId());
+      nodes.add(node);
+    }
+    Cluster cluster = new Cluster("123", "user1", "hadoop", System.currentTimeMillis(), "hadoop cluster",
+                          Entities.ProviderExample.RACKSPACE, reactorTemplate, nodeIds,
+                          ImmutableSet.of(namenode.getName(), datanode.getName()));
+    Constraints constraints = cluster.getClusterTemplate().getConstraints();
+
+    NodeLayout masterNodeLayout = new NodeLayout("large-mem", "centos6", ImmutableSet.of("namenode"));
+    NodeLayout expandedMasterNodeLayout =
+      new NodeLayout("large-mem", "centos6", ImmutableSet.of(namenode.getName(), resourcemanager.getName()));
+    NodeLayout slaveLayout = new NodeLayout("medium", "centos6", ImmutableSet.of(datanode.getName()));
+    NodeLayout expandedSlaveLayout =
+      new NodeLayout("medium", "centos6", ImmutableSet.of(datanode.getName(), nodemanager.getName()));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    AddServicesChange resourceManagerChange = new AddServicesChange(counts, resourcemanager.getName());
+    counts = HashMultiset.create();
+    counts.add(slaveLayout, 25);
+    AddServicesChange nodeManagerChange = new AddServicesChange(counts, nodemanager.getName());
+
+    Cluster expectedCluster = copyOfClusterWith(cluster, ImmutableSet.of(
+      namenode.getName(), datanode.getName(), resourcemanager.getName()));
+    counts = HashMultiset.create();
+    counts.add(expandedMasterNodeLayout);
+    counts.add(slaveLayout, 50);
+    ClusterLayout expectedLayout = new ClusterLayout(constraints, counts);
+    resourceManagerChange.applyChange(cluster, nodes, serviceMap);
+    Assert.assertEquals(expectedCluster, cluster);
+    Assert.assertEquals(expectedLayout, ClusterLayout.fromNodes(nodes, constraints));
+
+    expectedCluster = copyOfClusterWith(cluster, ImmutableSet.of(
+      namenode.getName(), datanode.getName(), resourcemanager.getName(), nodemanager.getName()));
+    counts = HashMultiset.create();
+    counts.add(expandedMasterNodeLayout);
+    counts.add(expandedSlaveLayout, 25);
+    counts.add(slaveLayout, 25);
+    expectedLayout = new ClusterLayout(constraints, counts);
+    nodeManagerChange.applyChange(cluster, nodes, serviceMap);
+    Assert.assertEquals(expectedCluster, cluster);
+    Assert.assertEquals(expectedLayout, ClusterLayout.fromNodes(nodes, constraints));
+
+    counts = HashMultiset.create();
+    counts.add(expandedMasterNodeLayout);
+    counts.add(expandedSlaveLayout, 50);
+    expectedLayout = new ClusterLayout(constraints, counts);
+    nodeManagerChange.applyChange(cluster, nodes, serviceMap);
+    Assert.assertEquals(expectedCluster, cluster);
+    Assert.assertEquals(expectedLayout, ClusterLayout.fromNodes(nodes, constraints));
+  }
+
+  private Cluster copyOfClusterWith(Cluster cluster, Set<String> services) {
+    return new Cluster(cluster.getId(), cluster.getOwnerId(), cluster.getName(),
+                       cluster.getCreateTime(), cluster.getDescription(), cluster.getProvider(),
+                       cluster.getClusterTemplate(), cluster.getNodes(), services);
+  }
+
+  @BeforeClass
+  public static void beforeClass() {
+    constraints = new Constraints(
+      ImmutableMap.<String, ServiceConstraint>of(
+        "namenode",
+        new ServiceConstraint(
+          ImmutableSet.of("large-mem"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 1, 1, null),
+        "datanode",
+        new ServiceConstraint(
+          ImmutableSet.of("medium", "large-cpu"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null),
+        "zookeeper",
+        new ServiceConstraint(
+          ImmutableSet.of("small", "medium"),
+          ImmutableSet.of("centos6"), 1, 5, 2, ImmutablePair.of(1, 20)),
+        "reactor",
+        new ServiceConstraint(
+          ImmutableSet.of("medium", "large"),
+          null, 1, 5, 1, ImmutablePair.of(1, 10))
+      ),
+      new LayoutConstraint(
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("datanode", "nodemanager", "regionserver"),
+          ImmutableSet.of("namenode", "resourcemanager", "hbasemaster")
+        ),
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("datanode", "namenode"),
+          ImmutableSet.of("datanode", "zookeeper"),
+          ImmutableSet.of("namenode", "zookeeper"),
+          ImmutableSet.of("datanode", "reactor"),
+          ImmutableSet.of("namenode", "reactor")
+        )
+      )
+    );
+  }
+}

--- a/server/src/test/java/com/continuuity/loom/layout/change/ClusterLayoutTrackerTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/change/ClusterLayoutTrackerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.layout.change;
+
+import com.continuuity.loom.admin.Constraints;
+import com.continuuity.loom.admin.LayoutConstraint;
+import com.continuuity.loom.admin.ServiceConstraint;
+import com.continuuity.loom.layout.ClusterLayout;
+import com.continuuity.loom.layout.NodeLayout;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ *
+ */
+public class ClusterLayoutTrackerTest {
+  private static Constraints constraints;
+
+  @Test
+  public void testAddIfValidDoesNotAddInvalid() {
+    NodeLayout masterNodeLayout = new NodeLayout("large", "centos6", ImmutableSet.of("master1"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    ClusterLayout layout = new ClusterLayout(constraints, counts);
+    ClusterLayoutTracker tracker = new ClusterLayoutTracker(layout);
+
+    counts = HashMultiset.create();
+    counts.add(new NodeLayout("medium", "centos6", ImmutableSet.of("master1")));
+    Assert.assertFalse(tracker.addChangeIfValid(new AddServicesChange(counts, "slave1")));
+  }
+
+  @Test
+  public void testAddAndRemove() {
+    NodeLayout masterNodeLayout = new NodeLayout("large", "centos6", ImmutableSet.of("master1"));
+    NodeLayout slaveNodeLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("slave1"));
+    NodeLayout expandedSlaveNodeLayout = new NodeLayout("medium", "centos6", ImmutableSet.of("slave1", "slave2"));
+    Multiset<NodeLayout> counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(slaveNodeLayout, 5);
+    ClusterLayout originalLayout = new ClusterLayout(constraints, counts);
+    ClusterLayoutTracker tracker = new ClusterLayoutTracker(originalLayout);
+
+    // add slave2 to 3 slave nodes
+    counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(expandedSlaveNodeLayout, 3);
+    counts.add(slaveNodeLayout, 2);
+    ClusterLayout expectedMiddleState = new ClusterLayout(constraints, counts);
+    counts = HashMultiset.create();
+    counts.add(slaveNodeLayout, 3);
+    Assert.assertTrue(tracker.addChangeIfValid(new AddServicesChange(counts, "slave2")));
+    Assert.assertEquals(expectedMiddleState, tracker.getCurrentLayout());
+
+    // add slave2 to rest of slave nodes
+    counts = HashMultiset.create();
+    counts.add(masterNodeLayout);
+    counts.add(expandedSlaveNodeLayout, 5);
+    ClusterLayout expectedEndState = new ClusterLayout(constraints, counts);
+    counts = HashMultiset.create();
+    counts.add(slaveNodeLayout, 2);
+    Assert.assertTrue(tracker.addChangeIfValid(new AddServicesChange(counts, "slave2")));
+    Assert.assertEquals(expectedEndState, tracker.getCurrentLayout());
+
+    // remove last change
+    tracker.removeLastChange();
+    Assert.assertEquals(expectedMiddleState, tracker.getCurrentLayout());
+
+    // remove last change
+    tracker.removeLastChange();
+    Assert.assertEquals(originalLayout, tracker.getCurrentLayout());
+  }
+
+
+  @BeforeClass
+  public static void beforeClass() {
+    constraints = new Constraints(
+      ImmutableMap.<String, ServiceConstraint>of(
+        "master1",
+        new ServiceConstraint(
+          ImmutableSet.of("large"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 1, 1, null),
+        "slave1",
+        new ServiceConstraint(
+          ImmutableSet.of("medium"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null),
+        "slave2",
+        new ServiceConstraint(
+          ImmutableSet.of("medium"),
+          ImmutableSet.of("centos6", "ubuntu12"), 1, 50, 1, null)
+      ),
+      new LayoutConstraint(
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("slave1", "slave2")
+        ),
+        ImmutableSet.<Set<String>>of(
+          ImmutableSet.of("master1", "slave1"),
+          ImmutableSet.of("master1", "slave2")
+        )
+      )
+    );
+  }
+}


### PR DESCRIPTION
of a ClusterLayoutChange, which can apply some sort of change
to a ClusterLayout. Currently only an AddServicesChange is
implemented, but we can add ones for removing a service or adding
nodes in the future. Also changing the solver interface a bit
to return a diff of cluster layout when adding services to an
existing layout.
