### PR TITLE
Feature/update hadoop wrapper cookbook

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/default.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/default.rb
@@ -7,7 +7,7 @@ default['java']['oracle']['accept_oracle_download_terms'] = true
 # core-site.xml
 default['hadoop']['core_site']['hadoop.tmp.dir'] = '/hadoop'
 # hdfs-site.xml
-default['hadoop']['hdfs_site']['dfs.datanode.max.xcievers'] = '4096'
+default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
 # mapred-site.xml
 default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
 # yarn-site.xml

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/krb5.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/attributes/krb5.rb
@@ -1,7 +1,7 @@
 # Hadoop
-if node['hadoop'].key? 'core_site' and node['hadoop']['core_site'].key? 'hadoop.security.authorization' and
-  node['hadoop']['core_site'].key? 'hadoop.security.authentication' and
-  node['hadoop']['core_site']['hadoop.security.authorization'].to_s == 'true' and
+if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.security.authorization') &&
+  node['hadoop']['core_site'].key?('hadoop.security.authentication') &&
+  node['hadoop']['core_site']['hadoop.security.authorization'].to_s == 'true' &&
   node['hadoop']['core_site']['hadoop.security.authentication'] == 'kerberos'
 
   include_attribute 'krb5'
@@ -12,7 +12,7 @@ if node['hadoop'].key? 'core_site' and node['hadoop']['core_site'].key? 'hadoop.
   default['hadoop']['container_executor']['min.user.id'] = 500
   default['hadoop']['container_executor']['yarn.nodemanager.linux-container-executor.group'] = 'yarn'
   default['hadoop']['container_executor']['yarn.nodemanager.local-dirs'] =
-    if node['hadoop'].key? 'yarn_site' and node['hadoop']['yarn_site'].key? 'yarn.nodemanager.local-dirs'
+    if node['hadoop'].key?('yarn_site') && node['hadoop']['yarn_site'].key?('yarn.nodemanager.local-dirs')
       node['hadoop']['yarn_site']['yarn.nodemanager.local-dirs']
     elsif node['hadoop'].key? 'hadoop.tmp.dir'
       "#{node['hadoop']['hadoop.tmp.dir']}/nm-local-dir"
@@ -57,9 +57,9 @@ if node['hadoop'].key? 'core_site' and node['hadoop']['core_site'].key? 'hadoop.
 end
 
 # HBase
-if node['hbase'].key? 'hbase_site' and node['hbase']['hbase_site'].key? 'hbase.security.authorization' and
-  node['hbase']['hbase_site'].key? 'hbase.security.authentication' and
-  node['hbase']['hbase_site']['hbase.security.authorization'].to_s == 'true' and
+if node['hbase'].key?('hbase_site') && node['hbase']['hbase_site'].key?('hbase.security.authorization') &&
+  node['hbase']['hbase_site'].key?('hbase.security.authentication') &&
+  node['hbase']['hbase_site']['hbase.security.authorization'].to_s == 'true' &&
   node['hbase']['hbase_site']['hbase.security.authentication'] == 'kerberos'
 
   include_attribute 'krb5'

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/metadata.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/metadata.rb
@@ -6,6 +6,10 @@ description      'Hadoop wrapper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.1'
 
-%w(apt java hadoop yum krb5 krb5_utils).each do |cb|
+%w(apt hadoop java krb5_utils yum).each do |cb|
   depends cb
 end
+
+depends 'mysql', '< 5.0.0'
+depends 'database', '< 2.1.0'
+depends 'krb5', '>= 1.0.0'

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/default.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/default.rb
@@ -20,7 +20,7 @@
 # We require Java, and the Hadoop cookbook doesn't have it as a dependency
 include_recipe 'java::default'
 
-if node.key? 'java' and node['java'].key? 'java_home'
+if node.key?('java') && node['java'].key?('java_home')
 
   Chef::Log.info("JAVA_HOME = #{node['java']['java_home']}")
 

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/hbase_master_init.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/hbase_master_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: hadoop_wrapper
 # Recipe:: hbase_master_init
 #
-# Copyright (C) 2013 Continuuity, Inc.
+# Copyright (C) 2013-2014 Continuuity, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@
 
 include_recipe 'hadoop_wrapper::default'
 include_recipe 'hadoop::hbase_master'
-
-dfs = node['hadoop']['core_site']['fs.defaultFS']
 
 if node['hbase']['hbase_site']['hbase.rootdir'] =~ %r{^/|^hdfs://} && node['hbase']['hbase_site']['hbase.cluster.distributed'].to_s == 'true'
   # bootstrap HDFS for HBase

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/hive_metastore_db_init.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/hive_metastore_db_init.rb
@@ -1,0 +1,113 @@
+#
+# Cookbook Name:: hadoop_wrapper
+# Recipe:: hive_metastore_db_init
+#
+# Copyright (C) 2014 Continuuity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop_wrapper::default'
+include_recipe 'hadoop::default'
+include_recipe 'hadoop::hive_metastore'
+
+# Set up our database
+if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionURL')
+  jdo_array = node['hive']['hive_site']['javax.jdo.option.ConnectionURL'].split(':')
+  hive_uris = node['hive']['hive_site']['hive.metastore.uris'].gsub('thrift://', '').gsub(':9083', '').split(',')
+  db_type = jdo_array[1]
+  db_name = jdo_array[2].split('/').last.split('?').first
+  db_user =
+    if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionUserName')
+      node['hive']['hive_site']['javax.jdo.option.ConnectionUserName']
+    end
+  db_pass =
+    if node['hive'].key?('hive_site') && node['hive']['hive_site'].key?('javax.jdo.option.ConnectionPassword')
+      node['hive']['hive_site']['javax.jdo.option.ConnectionPassword']
+    end
+  sql_dir = '/usr/lib/hive/scripts/metastore/upgrade'
+
+  case db_type
+  when 'mysql'
+    include_recipe 'database::mysql'
+    mysql_connection_info = {
+      :host     => 'localhost',
+      :username => 'root',
+      :password => node['mysql']['server_root_password']
+    }
+    mysql_database db_name do
+      connection mysql_connection_info
+      action :create
+    end
+    mysql_database_user db_user do
+      connection mysql_connection_info
+      password db_pass
+      action :create
+    end
+    mysql_database 'import-hive-schema' do
+      connection mysql_connection_info
+      database_name db_name
+      sql lazy { ::File.open(Dir.glob("#{sql_dir}/mysql/hive-schema-*").sort_by! { |s| s[/\d+/].to_i }.last).read }
+      action :query
+    end
+    hive_uris.each do |hive_host|
+      mysql_database_user "#{db_user}-#{hive_host}" do
+        connection mysql_connection_info
+        username db_user
+        database_name db_name
+        password db_pass
+        host hive_host
+        privileges ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'LOCK TABLES', 'EXECUTE']
+        action :grant
+      end
+    end
+
+  when 'postgresql'
+    include_recipe 'database::postgresql'
+    postgresql_connection_info = {
+      :host     => '127.0.0.1',
+      :port     => node['postgresql']['config']['port'],
+      :username => 'postgres',
+      :password => node['postgresql']['password']['postgres']
+    }
+    postgresql_database db_name do
+      connection postgresql_connection_info
+      action :create
+    end
+    postgresql_database_user db_user do
+      connection postgresql_connection_info
+      password db_pass
+      action :create
+    end
+    postgresql_database 'import-hive-schema' do
+      connection postgresql_connection_info
+      database_name db_name
+      sql lazy { ::File.open(Dir.glob("#{sql_dir}/postgres/hive-schema-*").sort_by! { |s| s[/\d+/].to_i }.last).read }
+      action :query
+    end
+    hive_uris.each do |hive_host|
+      postgresql_database_user "#{db_user}-#{hive_host}" do
+        connection postgresql_connection_info
+        username db_user
+        database_name db_name
+        password db_pass
+        host hive_host
+#        privileges %w(SELECT INSERT UPDATE DELETE)
+        privileges [:all]
+        action :grant
+      end
+    end
+  else
+    Chef::Log.info('Only MySQL and PostgreSQL are supported for automatically creating users and databases')
+  end
+end

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/kerberos_init.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/cookbooks/hadoop_wrapper/recipes/kerberos_init.rb
@@ -18,10 +18,10 @@
 #
 
 # Enable kerberos security
-if node['hadoop'].key? 'core_site' and node['hadoop']['core_site'].key? 'hadoop.security.authorization' and
-  node['hadoop']['core_site'].key? 'hadoop.security.authentication' and
-  node['hadoop']['core_site']['hadoop.security.authorization'].to_s == 'true' and
-  node['hadoop']['core_site']['hadoop.security.authentication'].downcase == 'kerberos'
+if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.security.authorization') &&
+  node['hadoop']['core_site'].key?('hadoop.security.authentication') &&
+  node['hadoop']['core_site']['hadoop.security.authorization'].to_s == 'true' &&
+  node['hadoop']['core_site']['hadoop.security.authentication'] == 'kerberos'
 
   include_recipe 'krb5'
   Chef::Log.info("Secure Hadoop Enabled: Kerberos Realm '#{node['krb5']['krb5_conf']['realms']['default_realm']}'")
@@ -64,10 +64,10 @@ if node['hadoop'].key? 'core_site' and node['hadoop']['core_site'].key? 'hadoop.
   end
 end
 
-if node['hbase'].key? 'hbase_site' and node['hbase']['hbase_site'].key? 'hbase.security.authorization' and
-  node['hbase']['hbase_site'].key? 'hbase.security.authentication' and
-  node['hbase']['hbase_site']['hbase.security.authorization'].to_s == 'true' and
-  node['hbase']['hbase_site']['hbase.security.authentication'].downcase == 'kerberos'
+if node['hbase'].key?('hbase_site') && node['hbase']['hbase_site'].key?('hbase.security.authorization') &&
+  node['hbase']['hbase_site'].key?('hbase.security.authentication') &&
+  node['hbase']['hbase_site']['hbase.security.authorization'].to_s == 'true' &&
+  node['hbase']['hbase_site']['hbase.security.authentication'] == 'kerberos'
 
   if secure_hadoop_enabled.nil?
     Chef::Application.fatal!('You must enable kerberos in Hadoop or disable kerberos for HBase!')


### PR DESCRIPTION
This is an update to the hadoop_wrapper cookbook to add a hive_metastore_db_init recipe, to initialize mysql/postgresql database for Hive use.
