### PR TITLE
Update imagetypes for centos6 and ubuntu12 to latest from Joyent/Rackspace

### DIFF
--- a/config/defaults/imagetypes/centos6.json
+++ b/config/defaults/imagetypes/centos6.json
@@ -3,10 +3,10 @@
   "description": "CentOS 6",
   "providermap": {
     "joyent": {
-      "image": "30e9e4c8-bbf2-11e2-ac3b-3b598ee13393"
+      "image": "19daa264-c4c4-11e3-bec3-c30e2c0d4ec0"
     },
     "rackspace": {
-      "image": "f70ed7c7-b42e-4d77-83d8-40fa29825b85"
+      "image": "042395fc-728c-4763-86f9-9b0cacb00701"
     }
   }
 }

--- a/config/defaults/imagetypes/ubuntu12.json
+++ b/config/defaults/imagetypes/ubuntu12.json
@@ -6,7 +6,7 @@
       "image": "d2ba0f30-bbe8-11e2-a9a2-6bc116856d85"
     },
     "rackspace": {
-      "image": "80fbcb55-b206-41f9-9bc2-2dd7aac6c061"
+      "image": "ffa476b1-9b14-46bd-99a8-862d1d94eb7a"
     }
   }
 }

--- a/examples/imagetypes/centos6.json
+++ b/examples/imagetypes/centos6.json
@@ -3,10 +3,10 @@
   "description": "CentOS 6",
   "providermap": {
     "joyent": {
-      "image": "30e9e4c8-bbf2-11e2-ac3b-3b598ee13393"
+      "image": "19daa264-c4c4-11e3-bec3-c30e2c0d4ec0"
     },
     "rackspace": {
-      "image": "f70ed7c7-b42e-4d77-83d8-40fa29825b85"
+      "image": "042395fc-728c-4763-86f9-9b0cacb00701"
     }
   }
 }

--- a/examples/imagetypes/ubuntu12.json
+++ b/examples/imagetypes/ubuntu12.json
@@ -6,7 +6,7 @@
       "image": "d2ba0f30-bbe8-11e2-a9a2-6bc116856d85"
     },
     "rackspace": {
-      "image": "80fbcb55-b206-41f9-9bc2-2dd7aac6c061"
+      "image": "ffa476b1-9b14-46bd-99a8-862d1d94eb7a"
     }
   }
 }


### PR DESCRIPTION
These images include fixes for Heartbleed
