### PR TITLE
Feature/dotchef knifedotrb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,11 @@ Vagrantfile
 chefignore
 
 # Environment
-.bash*
-.chef
-.gem
-.lesshst
-.m2
-.profile
-.ssh
-.viminfo
+/.bash*
+/.chef
+/.gem
+/.lesshst
+/.m2
+/.profile
+/.ssh
+/.viminfo

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator/.chef/knife.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator/.chef/knife.rb
@@ -1,0 +1,3 @@
+log_level                :info
+log_location             STDOUT
+cookbook_path            [ "#{File.dirname(__FILE__)}/../cookbooks" ]


### PR DESCRIPTION
Adding knife.rb to chef_automator to make it easier to work with Chef cookbooks. Otherwise, you must always specify the cookbook_path when running knife commands, such as `knife cookbook test` or `knife cookbook site install`...
