### PR TITLE
Hotfix/fixes for latest images

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator.rb
@@ -160,6 +160,35 @@ class ChefAutomator < Automator
       raise $!, "SSH Authentication failure for #{ipaddress}: #{$!}", $!.backtrace
     end
 
+    # check to ensure scp is installed and attempt to install it
+    begin
+      Net::SSH.start(ipaddress, inputmap['sshauth']['user'], @credentials) do |ssh|
+
+        log.debug "Checking for scp installation"
+        begin
+          ssh_exec!(ssh, "which scp")
+        rescue
+          log.warn "scp not found, attempting to install openssh-client"
+          scp_install_cmd = "yum -qy install openssh-clients"
+          begin
+            ssh_exec!(ssh, "which yum")
+          rescue
+            scp_install_cmd = "apt-get -qy install openssh-client"
+          end
+
+          begin
+            log.debug "installing openssh-client via #{scp_install_cmd}"
+            ssh_exec!(ssh, scp_install_cmd)
+          rescue => e
+            raise $!, "Could not install scp on #{ipaddress}: #{$!}", $!.backtrace
+          end
+        end
+        log.debug "scp found on remote"
+      end
+    rescue Net::SSH::AuthenticationFailed => e
+      raise $!, "SSH Authentication failure for #{ipaddress}: #{$!}", $!.backtrace
+    end
+
     # upload tarballs to target machine
     %w[cookbooks data_bags roles].each do |chef_primitive|
       log.debug "Uploading #{chef_primitive} from #{@chef_primitives_path}/#{chef_primitive}.tar.gz to #{ipaddress}:#{@remote_cache_dir}/#{chef_primitive}.tar.gz"

--- a/provisioner/daemon/plugins/automators/chef_automator/chef_automator.rb
+++ b/provisioner/daemon/plugins/automators/chef_automator/chef_automator.rb
@@ -114,9 +114,19 @@ class ChefAutomator < Automator
         log.debug "Validating connectivity to #{hostname}"
         output = ssh_exec!(ssh, "hostname")
 
+        # determine if curl is installed, else default to wget
+        log.debug "Checking for curl"
+        chef_install_cmd = "curl -L https://www.opscode.com/chef/install.sh | bash"
+        begin
+          ssh_exec!(ssh, "which curl")
+        rescue
+          log.debug "curl not found, defaulting to wget"
+          chef_install_cmd = "wget -qO - https://www.opscode.com/chef/install.sh | bash"
+        end
+
         # install chef
         log.debug "Install chef..."
-        output = ssh_exec!(ssh, "curl -L https://www.opscode.com/chef/install.sh | bash")
+        output = ssh_exec!(ssh, chef_install_cmd)
         if (output[2] != 0 )
           log.error "Chef install failed: #{output}"
           raise "Chef install failed: #{output}"

--- a/provisioner/daemon/plugins/providers/rackspace_provider/chef/knife/loom_rackspace_server_confirm.rb
+++ b/provisioner/daemon/plugins/providers/rackspace_provider/chef/knife/loom_rackspace_server_confirm.rb
@@ -96,6 +96,12 @@ class Chef
           exit 1
         end
 
+        print "\n#{ui.color("Waiting for sshd", :magenta)}"
+        print(".") until tcp_test_ssh(bootstrap_ip_address) {
+          sleep @initial_sleep_delay ||= 10
+          puts("done")
+        }
+
         puts ui.color("Bootstrap IP Address #{bootstrap_ip_address}", :cyan)
 
         return { "status" => 0, "ipaddress" => bootstrap_ip_address }


### PR DESCRIPTION
updating to the latest provider images raised several issues, which this PR addresses:
- [x] curl not included in the minimal images.  for chef install, added a check for curl and default to wget if not installed
- [x] scp not installed in the minimal images.  Added a check for it, and attempt a yum or apt-get install.  This is a bit ugly, and needs to be added to both automators.
- [x] rackspace new images empirically more susceptible to connection refused errors.  added the tcp_test_ssh and sleep from the latest knife_rackspace gem
