### PR TITLE
labels are required

### DIFF
--- a/provisioner/daemon/plugins/providers/openstack_provider/openstack_provider.json
+++ b/provisioner/daemon/plugins/providers/openstack_provider/openstack_provider.json
@@ -55,15 +55,18 @@
         "fields": {
           "security_groups": {
             "type": "text",
+            "label": "Security Group",
             "default": "default",
             "tip": "Openstack security groups (comma separated)"
           },
           "availability_zone": {
             "type": "text",
+            "label": "Availability Zone",
             "tip": "Openstack Availability Zone"
           },
           "floating_ip": {
             "type": "checkbox",
+            "label": "Floating IP",
             "tip": "Request a floating IP address for each node"
           }
         },


### PR DESCRIPTION
adding labels, which prevents openstack plugin from failing to register
