### PR TITLE
Hotfix/report registration failures

### DIFF
--- a/bin/loom-provisioner.sh
+++ b/bin/loom-provisioner.sh
@@ -68,7 +68,7 @@ start ( ) {
 register ( ) {
   echo "Registering provisioner plugins with server ${LOOM_SERVER_URI}"
   nice -1 ${LOOM_RUBY} ${PROVISIONER_PATH}/provisioner.rb --uri ${LOOM_SERVER_URI} \
-      -L ${LOOM_LOG_LEVEL} --register >> ${LOOM_LOG_DIR}/${APP_NAME}${p}.log 2>&1
+      -L ${LOOM_LOG_LEVEL} --register 
 }
 
 

--- a/provisioner/daemon/pluginmanager.rb
+++ b/provisioner/daemon/pluginmanager.rb
@@ -19,11 +19,20 @@ require_relative 'automator'
 require_relative 'provider'
 
 class PluginManager
-  attr_accessor :providermap, :automatormap, :tasks
+  attr_accessor :providermap, :automatormap, :tasks, :load_errors, :register_errors
   def initialize()
+    @load_errors = Array.new
+    @register_errors = Array.new
     @providermap = Hash.new{ |h,k| h[k] = Hash.new(&h.default_proc) }
     @automatormap = Hash.new{ |h,k| h[k] = Hash.new(&h.default_proc) }
     scan_plugins()
+  end
+
+  def load_errors?
+    return !@load_errors.empty?
+  end
+  def register_errors?
+    return !@load_errors.empty?
   end
 
   # scan plugins directory for json plugin definitions, load plugins 
@@ -79,11 +88,13 @@ class PluginManager
         log.error "Could not load plugin, invalid json at #{jsonfile}"
         log.error e.message
         log.error e.backtrace.inspect
+        @load_errors.push("Could not load plugin, invalid json at #{jsonfile}")
         next
       rescue => e
         log.error "Could not load plugin at #{jsonfile}"
         log.error e.message
         log.error e.backtrace.inspect
+        @load_errors.push("Could not load plugin at #{jsonfile}")
         next
       end 
     end
@@ -107,11 +118,13 @@ class PluginManager
         log.info "Successfully registered #{name}"
       else
         log.error "Response code #{resp.code}, #{resp.to_str} when trying to register #{name}"
+        @register_errors.push("Response code #{resp.code}, #{resp.to_str} when trying to register #{name}")
       end
     rescue => e
       log.error "Caught exception registering plugins to loom server #{uri}"
       log.error e.message
       log.error e.backtrace.inspect
+      @register_errors.push("Caught exception registering plugins to loom server #{uri}")
     end
   end
 

--- a/provisioner/daemon/provisioner.rb
+++ b/provisioner/daemon/provisioner.rb
@@ -140,6 +140,14 @@ end
 # register plugins with the server if --register flag passed
 if options[:register]
   pluginmanager.register_plugins(loom_uri)
+  if (pluginmanager.load_errors?)
+    log.error "There was at least one provisioner plugin load failure"
+    exit(1)
+  end
+  if (pluginmanager.register_errors?)
+    log.error "There was at least one provisioner plugin register failure"
+    exit(1)
+  end
   exit(0)
 end
 


### PR DESCRIPTION
provisioner output was being redirected into a unnumbered provisioner log file.  This is the only place where errors during plugin loading/registration can be seen.
- [x] remove redirection so $LOOM_HOME/bin/loom-provisioner.sh register logs to STDOUT
- [x] some basic tracking of errors by the pluginmanager, so that proper exit code of --register can be determined.  

```
Waiting for server to start before loading default configuration...
Loading default configuration...
Registering provisioner plugins with server http://localhost:55054
2014-05-06 13:26:28 -0700 INFO: Successfully registered joyent
2014-05-06 13:26:28 -0700 INFO: Successfully registered openstack
2014-05-06 13:26:28 -0700 INFO: Successfully registered rackspace
2014-05-06 13:26:28 -0700 INFO: Successfully registered chef
2014-05-06 13:26:28 -0700 INFO: Successfully registered shell

Go to http://localhost:8100. Have fun creating clusters!
```
