### PR TITLE
Hotfix/shell provisioner invocation

### DIFF
--- a/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
+++ b/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
@@ -70,11 +70,15 @@ if [ -f ${USERSCRIPT} ]; then
     # source it, so that it can make use of the function(s) above
     . ${USERSCRIPT} $*
   else
-    # not a shell script, just execute it
-    ./${USERSCRIPT} $*
+    # not a shell script, check if executable
+    if [ -x ${USERSCRIPT} ]; then
+      ./${USERSCRIPT} $*
+    else
+      echo "Argument #{USERSCRIPT} must be executable or a bash script with a proper sha-bang header"
+      exit 1
+    fi
   fi
 else
-  # default to running it as a command
+  # not a file, try running it as a command
   ${USERSCRIPT} $*
 fi
-

--- a/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
+++ b/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
@@ -63,5 +63,18 @@ loom_lookup_key () {
   fi
 }
 
-. $USERSCRIPT $*
+if [ -f ${USERSCRIPT} ]; then
+  # USERSCRIPT is a file.  Check if it is a shell script
+  file ${USERSCRIPT} | grep "shell.*executable" 2>&1 >/dev/null
+  if [ $? == 0 ]; then
+    # source it, so that it can make use of the function(s) above
+    . ${USERSCRIPT} $*
+  else
+    # not a shell script, just execute it
+    ./${USERSCRIPT} $*
+  fi
+else
+  # default to running it as a command
+  ${USERSCRIPT} $*
+fi
 


### PR DESCRIPTION
This fixes a bug in the current shell automator where it fails if you specify anything other than an included script.  It was attempting to source whatever you gave it.

This PR attempts to detect if it's a bash script and only then will source it.  Otherwise, it just executes it.
