### PR TITLE
constrain to single hive-metastore

### DIFF
--- a/config/defaults/clustertemplates/hadoop-distributed.json
+++ b/config/defaults/clustertemplates/hadoop-distributed.json
@@ -90,8 +90,7 @@
         [
           "hadoop-hdfs-datanode",
           "hadoop-yarn-nodemanager",
-          "hbase-regionserver",
-          "hive-metastore"
+          "hbase-regionserver"
         ],
         [
           "hadoop-hdfs-namenode",
@@ -99,6 +98,7 @@
           "hbase-master",
           "mysql-server",
           "hive-metastore-database",
+          "hive-metastore",
           "zookeeper-server",
           "hive-server2"
         ]
@@ -106,8 +106,7 @@
       "cantcoexist": [
         [ "hadoop-yarn-resourcemanager", "hadoop-yarn-nodemanager" ],
         [ "hadoop-hdfs-namenode", "hadoop-hdfs-datanode" ],
-        [ "hbase-master", "hbase-regionserver" ],
-        [ "hive-metastore", "hive-server2" ]
+        [ "hbase-master", "hbase-regionserver" ]
       ]
     },
     "services": {


### PR DESCRIPTION
constraining hive-metastore service to a single instance per cloudera docs, etc.
