### PR TITLE
Hotfix/kerberos support

### DIFF
--- a/config/defaults/services/hadoop-hdfs-datanode.json
+++ b/config/defaults/services/hadoop-hdfs-datanode.json
@@ -5,12 +5,12 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
       "requires": [ "hadoop-hdfs-namenode" ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hadoop-hdfs-namenode.json
+++ b/config/defaults/services/hadoop-hdfs-namenode.json
@@ -5,12 +5,12 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
       "requires": [],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hadoop-yarn-nodemanager.json
+++ b/config/defaults/services/hadoop-yarn-nodemanager.json
@@ -5,12 +5,12 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
       "requires": [ "hadoop-yarn-resourcemanager" ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hadoop-yarn-resourcemanager.json
+++ b/config/defaults/services/hadoop-yarn-resourcemanager.json
@@ -5,12 +5,12 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
       "requires": [ "hadoop-hdfs-namenode", "hadoop-hdfs-datanode" ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hbase-master.json
+++ b/config/defaults/services/hbase-master.json
@@ -5,7 +5,7 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
@@ -14,7 +14,7 @@
         "hadoop-hdfs-datanode",
         "zookeeper-server"
       ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hbase-regionserver.json
+++ b/config/defaults/services/hbase-regionserver.json
@@ -5,7 +5,7 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
@@ -13,7 +13,7 @@
         "hbase-master",
         "zookeeper-server"
       ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/hive-server2.json
+++ b/config/defaults/services/hive-server2.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "conflicts": [],
     "install": {
-      "requires": [],
-      "uses": []
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
@@ -17,7 +17,7 @@
         "zookeeper-server",
         "hive-metastore"
       ],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {

--- a/config/defaults/services/kerberos-client.json
+++ b/config/defaults/services/kerberos-client.json
@@ -9,7 +9,7 @@
     },
     "provides": [],
     "runtime": {
-      "requires": [],
+      "requires": [ "kerberos-master" ],
       "uses": []
     }
   },
@@ -17,15 +17,21 @@
     "actions": {
       "install": {
         "type":"chef-solo",
-        "script": "recipe[krb5::default]"
+        "fields": {
+          "run_list": "recipe[krb5::default]"
+        }
       },
       "initialize": {
         "type":"chef-solo",
-        "script": "recipe[krb5_utils::default]"
+        "fields": {
+          "run_list": "recipe[krb5_utils::default]"
+        }
       },
       "configure": {
         "type":"chef-solo",
-        "script": "recipe[krb5::default]"
+        "fields": {
+          "run_list": "recipe[krb5::default]"
+        }
       }
     }
   }

--- a/config/defaults/services/kerberos-master.json
+++ b/config/defaults/services/kerberos-master.json
@@ -4,12 +4,12 @@
   "dependencies": {
     "conflicts": [],
     "install": {
-      "requires": [ "base" ],
+      "requires": [ "base", "kerberos-client" ],
       "uses": []
     },
     "provides": [],
     "runtime": {
-      "requires": [ "kerberos-client" ],
+      "requires": [],
       "uses": []
     }
   },
@@ -17,25 +17,35 @@
     "actions": {
       "install": {
         "type":"chef-solo",
-        "script": "recipe[krb5::kadmin]"
+        "fields": {
+          "run_list": "recipe[krb5::kadmin]"
+        }
       },
       "configure": {
         "type":"chef-solo",
-        "script": "recipe[krb5::kadmin]"
+        "fields": {
+          "run_list": "recipe[krb5::kadmin]"
+        }
       },
       "initialize": {
         "type":"chef-solo",
-        "script": "recipe[krb5::kadmin_init]"
+        "fields": {
+          "run_list": "recipe[krb5::kadmin_init]"
+        }
       },
       "start": {
         "type": "chef-solo",
-        "script": "recipe[krb5::kadmin_service],recipe[loom_service_runner::default]",
-        "data": "{\"loom\": { \"node\": { \"services\": { \"krb5-admin-server\": \"start\" } } } }" 
+        "fields": {
+          "run_list": "recipe[krb5::kadmin_service],recipe[loom_service_runner::default]",
+          "json_attributes": "{\"loom\": { \"node\": { \"services\": { \"krb5-admin-server\": \"start\" } } } }"
+        }
       },
       "stop": {
         "type": "chef-solo",
-        "script": "recipe[krb5::kadmin_service],recipe[loom_service_runner::default]",
-        "data": "{\"loom\": { \"node\": { \"services\": { \"krb5-admin-server\": \"stop\" } } } }" 
+        "fields": {
+          "run_list": "recipe[krb5::kadmin_service],recipe[loom_service_runner::default]",
+          "json_attributes": "{\"loom\": { \"node\": { \"services\": { \"krb5-admin-server\": \"stop\" } } } }"
+        }
       }
     }
   }

--- a/config/defaults/services/zookeeper-server.json
+++ b/config/defaults/services/zookeeper-server.json
@@ -5,12 +5,12 @@
     "conflicts": [],
     "install": {
       "requires": [ "base" ],
-      "uses": []
+      "uses": [ "kerberos-client" ]
     },
     "provides": [],
     "runtime": {
       "requires": [],
-      "uses": []
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {


### PR DESCRIPTION
This fixes the `kerberos-client` and `kerberos-master` service JSON to use the correct fields for `chef-solo` automator. This also adds `kerberos-client` to install/uses and `kerberos-master` to runtime/uses on hadoop services (for secure Hadoop)...
