### PR TITLE
Add initialize to hadoop-yarn-resourcemanager service

### DIFF
--- a/config/defaults/services/hadoop-yarn-resourcemanager.json
+++ b/config/defaults/services/hadoop-yarn-resourcemanager.json
@@ -27,6 +27,12 @@
           "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
         }
       },
+      "initialize": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::hadoop_yarn_resourcemanager_init]"
+        }
+      },
       "start": {
         "type": "chef-solo",
         "fields": {


### PR DESCRIPTION
For some reason, there was no initialize step for hadoop-yarn-resourcemanager
