### PR TITLE
Hotfix/kerberos client

### DIFF
--- a/config/defaults/services/kerberos-client.json
+++ b/config/defaults/services/kerberos-client.json
@@ -9,8 +9,8 @@
     },
     "provides": [],
     "runtime": {
-      "requires": [ "kerberos-master" ],
-      "uses": []
+      "requires": [],
+      "uses": [ "kerberos-master" ]
     }
   },
   "provisioner": {


### PR DESCRIPTION
This fixes `kerberos-client` by moving its runtime dependency on `kerberos-master` to uses instead of requires.
