### PR TITLE
Hotfix/yarn container executor

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop_wrapper/attributes/krb5.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop_wrapper/attributes/krb5.rb
@@ -51,7 +51,6 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   default['hadoop']['yarn_site']['yarn.nodemanager.keytab'] = "#{node['krb5_utils']['keytabs_dir']}/yarn.service.keytab"
   default['hadoop']['yarn_site']['yarn.resourcemanager.principal'] = "yarn/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
   default['hadoop']['yarn_site']['yarn.nodemanager.principal'] = "yarn/_HOST@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
-  default['hadoop']['yarn_site']['yarn.nodemanager.container-executor.class'] = 'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
   default['hadoop']['yarn_site']['yarn.nodemanager.linux-container-executor.group'] = 'yarn'
 
 end


### PR DESCRIPTION
This option was causing glibc realloc errors. We need to investigate further before turning it back on...
