### PR TITLE
Fixing tests that were not revisited when callbacks were moved

### DIFF
--- a/server/src/test/java/com/continuuity/loom/scheduler/callback/MockClusterCallback.java
+++ b/server/src/test/java/com/continuuity/loom/scheduler/callback/MockClusterCallback.java
@@ -19,34 +19,24 @@ import com.continuuity.loom.conf.Configuration;
 import com.continuuity.loom.store.ClusterStore;
 import com.google.common.collect.Lists;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
  *
  */
 public class MockClusterCallback implements ClusterCallback {
-  private final List<CallbackData> startCallbacks = Lists.newArrayList();
-  private final List<CallbackData> successCallbacks = Lists.newArrayList();
-  private final List<CallbackData> failureCallbacks = Lists.newArrayList();
+  private final List<CallbackData> receivedCallbacks =
+    Collections.synchronizedList(Lists.<CallbackData>newArrayList());
   private boolean returnOnStart = true;
 
-  public List<CallbackData> getStartCallbacks() {
-    return startCallbacks;
-  }
-
-  public List<CallbackData> getSuccessCallbacks() {
-    return successCallbacks;
-  }
-
-  public List<CallbackData> getFailureCallbacks() {
-    return failureCallbacks;
-  }
-
   public void clear() {
-    startCallbacks.clear();
-    successCallbacks.clear();
-    failureCallbacks.clear();
+    receivedCallbacks.clear();
     returnOnStart = true;
+  }
+
+  public List<CallbackData> getReceivedCallbacks() {
+    return receivedCallbacks;
   }
 
   public void setReturnOnStart(boolean val) {
@@ -59,17 +49,17 @@ public class MockClusterCallback implements ClusterCallback {
 
   @Override
   public boolean onStart(CallbackData data) {
-    startCallbacks.add(data);
+    receivedCallbacks.add(data);
     return returnOnStart;
   }
 
   @Override
   public void onSuccess(CallbackData data) {
-    successCallbacks.add(data);
+    receivedCallbacks.add(data);
   }
 
   @Override
   public void onFailure(CallbackData data) {
-    failureCallbacks.add(data);
+    receivedCallbacks.add(data);
   }
 }


### PR DESCRIPTION
to run in their own threads. Also removing print statements.
