### PR TITLE
Feature/firewall updates

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/default.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-if node.has_key? 'loom_firewall'
+if node.key?('loom_firewall')
   include_recipe 'loom_firewall::iptables'
 else
   include_recipe 'loom_firewall::disable'

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/disable.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/disable.rb
@@ -20,7 +20,7 @@
 # Currently, we simply disable the firewall on RHEL
 case node['platform_family']
 when 'rhel'
-  service "iptables" do
+  service 'iptables' do
     action [ :disable, :stop ]
   end
 end

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/iptables.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/recipes/iptables.rb
@@ -17,34 +17,34 @@
 # limitations under the License.
 #
 
-package "iptables"
+package 'iptables'
 
 case node['platform_family']
 when 'debian'
   iptable_rules = '/etc/iptables-rules'
   file "/etc/network/if-up.d/iptables-rules" do
-    owner "root"
-    group "root"
-    mode "0755"
+    owner 'root'
+    group 'root'
+    mode '0755'
     content "#!/bin/bash\niptables-restore < #{iptable_rules}\n"
     action :create
   end
 when 'rhel'
   iptable_rules = '/etc/sysconfig/iptables'
-  service "iptables" do
+  service 'iptables' do
     supports [:restart, :reload, :status]
     action :enable
   end
 end
 
-execute "reload-iptables" do
+execute 'reload-iptables' do
   command "iptables-restore < #{iptable_rules}"
-  user "root"
+  user 'root'
   action :nothing
 end
 
 template iptable_rules do
-  source "iptables.erb"
-  notifies :run, "execute[reload-iptables]"
+  source 'iptables.erb'
+  notifies :run, 'execute[reload-iptables]'
   action :create
 end

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/templates/default/iptables.erb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_firewall/templates/default/iptables.erb
@@ -40,9 +40,15 @@ COMMIT
 ###
 *filter
 # node['loom_firewall']['INPUT_policy']
+<% if node['loom_firewall']['INPUT_policy'] %>
 :INPUT <%= node['loom_firewall']['INPUT_policy'] =%> [0:0]
+<% end %>
+<% if node['loom_firewall']['FORWARD_policy'] %>
 :FORWARD <%= node['loom_firewall']['FORWARD_policy'] =%> [0:0]
+<% end %>
+<% if node['loom_firewall']['OUTPUT_policy'] %>
 :OUTPUT <%= node['loom_firewall']['OUTPUT_policy'] =%> [0:0]
+<% end %>
 
 ## Allow traffic that is a part of an ongoing connection
 -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
@@ -84,6 +90,20 @@ COMMIT
 
 <% (node['loom']['cluster']['nodes'].sort_by {|n, v| v}).each do |n, v| %>
 -A INPUT -s <%= v.ipaddress =%> -j ACCEPT
+<% end %>
+
+<% if node['loom_firewall']['whitelist_nodes'] %>
+# Whitelisted nodes
+<% node['loom_firewall']['whitelist_nodes'].each do |n| %>
+-A INPUT -s <%= n =%> -j ACCEPT
+<% end %>
+<% end %>
+
+<% if node['loom_firewall']['blacklist_nodes'] %>
+# Blacklisted nodes
+<% node['loom_firewall']['blacklist_nodes'].each do |n| %>
+-A INPUT -s <%= n =%> -j DROP
+<% end %>
 <% end %>
 
 ###


### PR DESCRIPTION
This updates the firewall support in Loom to allow clusters to specify optional changes to firewall policies on INPUT, OUTPUT, and FORWARD tables and to specify optional whitelist/blacklist CIDR ranges to ACCEPT/DROP.

ex.

``` json
{"loom_firewall":{"whitelist_nodes":["1.2.3.4/32","10.0.0.0/8"]}}
```
