### PR TITLE
Feature/apache modules perl php python

### DIFF
--- a/config/defaults/clustertemplates/lamp.json
+++ b/config/defaults/clustertemplates/lamp.json
@@ -1,6 +1,6 @@
 {
   "name": "lamp",
-  "description": "LAMP stack (Linux, Apache, MySQL, PHP) with SSL and HAproxy support",
+  "description": "LAMP stack (Linux, Apache, MySQL, Perl/PHP/Python) with SSL and HAproxy support",
   "defaults": {
     "services": [
       "base",

--- a/config/defaults/clustertemplates/lamp.json
+++ b/config/defaults/clustertemplates/lamp.json
@@ -14,6 +14,24 @@
     "config": {
       "apache": {
         "default_site_enabled": "true"
+        "default_modules": [
+          "status",
+          "alias",
+          "auth_basic",
+          "authn_file",
+          "authz_default",
+          "authz_groupfile",
+          "authz_host",
+          "authz_user",
+          "autoindex",
+          "dir",
+          "env",
+          "mime",
+          "negotiation",
+          "setenvif",
+          "log_config",
+          "logio"
+        ]
       },
       "mysql": {
         "server_debian_password": "somedefaultpassword",

--- a/config/defaults/clustertemplates/lamp.json
+++ b/config/defaults/clustertemplates/lamp.json
@@ -1,6 +1,6 @@
 {
   "name": "lamp",
-  "description": "LAMP stack (Linux, Apache, MySQL, PHP) with HAproxy support",
+  "description": "LAMP stack (Linux, Apache, MySQL, PHP) with SSL and HAproxy support",
   "defaults": {
     "services": [
       "base",
@@ -33,7 +33,8 @@
           "logio",
           "perl",
           "php5",
-          "python"
+          "python",
+          "ssl"
         ]
       },
       "mysql": {

--- a/config/defaults/clustertemplates/lamp.json
+++ b/config/defaults/clustertemplates/lamp.json
@@ -30,7 +30,10 @@
           "negotiation",
           "setenvif",
           "log_config",
-          "logio"
+          "logio",
+          "perl",
+          "php5",
+          "python"
         ]
       },
       "mysql": {


### PR DESCRIPTION
This updates LAMP to support Perl and Python. It also adds the PHP5 module, to fix PHP support. Previously, PHP would be installed, but the web server did not know how to serve up PHP pages.

The list of modules is taken from the defaults in the apache2 cookbook, with perl, python, php5, and ssl added.
