### PR TITLE
check for script instead of shell

### DIFF
--- a/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
+++ b/provisioner/daemon/plugins/automators/shell_automator/scripts/.lib/loom_wrapper.sh
@@ -65,7 +65,7 @@ loom_lookup_key () {
 
 if [ -f ${USERSCRIPT} ]; then
   # USERSCRIPT is a file.  Check if it is a shell script
-  file ${USERSCRIPT} | grep "shell.*executable" 2>&1 >/dev/null
+  file ${USERSCRIPT} | grep "script.*executable" 2>&1 >/dev/null
   if [ $? == 0 ]; then
     # source it, so that it can make use of the function(s) above
     . ${USERSCRIPT} $*


### PR DESCRIPTION
the shell-provisioner json lookup wrapper is not properly detecting shell scripts.  this PR adjusts the expected output from the `file` command.  with this change, tests are now passing:

```
$ ./test.sh 
--- running tests array.sh ---
SUCCESS: output verified: foo bar
SUCCESS: output verified: a b c
SUCCESS: expected failure: non-unique key, multiple matches found
SUCCESS: output verified: a b
SUCCESS: output verified: name conflict
SUCCESS: foo "second element"
--- running tests duplicatekeys.sh ---
SUCCESS: expected failure: non-unique key, multiple matches found
SUCCESS: output verified: first
SUCCESS: output verified: nested
SUCCESS: expected failure: non-unique key, multiple matches found
SUCCESS: output verified: first
SUCCESS: output verified: first
SUCCESS: expected failure: non-unique key, multiple matches found
SUCCESS: output verified: first
SUCCESS: output verified: first
--- running tests nested.sh ---
SUCCESS: output verified: baz
SUCCESS: output verified: baz
SUCCESS: output verified: baz
SUCCESS: expected failure: key not found
--- running tests simplekey.sh ---
SUCCESS: output verified: 456
SUCCESS: output verified: 456
SUCCESS: output verified: a space
SUCCESS: expected failure: key not found
```
