### PR TITLE
use of the zookeeper namespace conf setting was accidentally

### DIFF
--- a/server/src/main/java/com/continuuity/loom/runtime/LoomServerMain.java
+++ b/server/src/main/java/com/continuuity/loom/runtime/LoomServerMain.java
@@ -216,13 +216,15 @@ public final class LoomServerMain extends DaemonMain {
 
   private ZKClientService getZKService(String connectString) {
     return ZKClientServices.delegate(
-      ZKClients.reWatchOnExpire(
-        ZKClients.retryOnFailure(
-          ZKClientService.Builder.of(connectString)
-            .setSessionTimeout(conf.getInt(Constants.ZOOKEEPER_SESSION_TIMEOUT_MILLIS))
-            .build(),
-          RetryStrategies.fixDelay(2, TimeUnit.SECONDS)
-        )
+      ZKClients.namespace(
+        ZKClients.reWatchOnExpire(
+          ZKClients.retryOnFailure(
+            ZKClientService.Builder.of(connectString)
+              .setSessionTimeout(conf.getInt(Constants.ZOOKEEPER_SESSION_TIMEOUT_MILLIS))
+              .build(),
+            RetryStrategies.fixDelay(2, TimeUnit.SECONDS)
+          )
+        ), conf.get(Constants.ZOOKEEPER_NAMESPACE)
       )
     );
   }


### PR DESCRIPTION
taken out during refactoring. Putting it back in.
