### PR TITLE
Import build-essential version 2.0.4

### DIFF
--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/CHANGELOG.md
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/CHANGELOG.md
@@ -2,6 +2,11 @@ build-essential Cookbook CHANGELOG
 ==================================
 This file is used to list changes made in each version of the build-essential cookbook.
 
+v2.0.4 (2014-06-06)
+-------------------
+* [COOK-4661] added patch package to _rhel recipe
+
+
 v2.0.2 (2014-05-02)
 -------------------
 - Updated documentation about older Chef versions

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/metadata.json
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "build-essential",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "Installs C compiler / build tools",
   "long_description": "",
   "maintainer": "Opscode, Inc.",

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/metadata.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs C compiler / build tools'
-version           '2.0.2'
+version           '2.0.4'
 recipe            'build-essential', 'Installs packages required for compiling C software from source.'
 
 %w{ fedora redhat centos ubuntu debian amazon suse scientific oracle smartos}.each do |os|

--- a/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/recipes/_rhel.rb
+++ b/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/build-essential/recipes/_rhel.rb
@@ -26,6 +26,7 @@ potentially_at_compile_time do
   package 'kernel-devel'
   package 'make'
   package 'm4'
+  package 'patch'
 
   # Ensure GCC 4 is available on older pre-6 EL
   if node['platform_version'].to_i < 6


### PR DESCRIPTION
This update solves this problem:

```
[snipped]hive_metastore_db_init.rb[0m
================================================================================[0m

[0m
NoMethodError[0m
-------------[0m
Undefined method or attribute `action' on `node'[0m

[0m
Cookbook Trace:[0m
---------------[0m
/var/chef/cookbooks/build-essential/libraries/timing.rb:109:in `method_missing'
/var/chef/cookbooks/build-essential/recipes/_rhel.rb:31:in `block in from_file'
/var/chef/cookbooks/build-essential/libraries/timing.rb:104:in `instance_eval'
/var/chef/cookbooks/build-essential/libraries/timing.rb:104:in `evaluate'
/var/chef/cookbooks/build-essential/libraries/timing.rb:47:in `potentially_at_compile_time'
/var/chef/cookbooks/build-essential/recipes/_rhel.rb:20:in `from_file'
/var/chef/cookbooks/build-essential/recipes/default.rb:21:in `from_file'
/var/chef/cookbooks/mysql/recipes/ruby.rb:24:in `from_file'
/var/chef/cookbooks/database/recipes/mysql.rb:20:in `from_file'
/var/chef/cookbooks/hadoop_wrapper/recipes/hive_metastore_db_init.rb:42:in `from_file'[0m

[0m
Relevant File Content:[0m
----------------------[0m
/var/chef/cookbooks/build-essential/libraries/timing.rb:

102: 
103: def evaluate(&block)
104: instance_eval(&block)
105: end
106: 
107: def method_missing(m, *args, &block)
108: resource = @recipe.send(m, *args, &block)
109>> actions = Array(resource.action)
110: resource.action(:nothing)
111: 
112: actions.each do |action|
113: resource.run_action(action)
114: end
115: end
116: end
117: end
118: end
[0m

[0m
[2014-06-26T22:57:13+00:00] ERROR: Running exception handlers
[2014-06-26T22:57:13+00:00] ERROR: Exception handlers complete
[2014-06-26T22:57:13+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-06-26T22:57:13+00:00] ERROR: Undefined method or attribute `action' on `node'
[2014-06-26T22:57:13+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

I tested it by running `chef-solo` on a failed cluster before this update, and after.
