### PR TITLE
make automator and provider types readable across all tenants and

### DIFF
--- a/server/src/main/java/com/continuuity/loom/http/LoomService.java
+++ b/server/src/main/java/com/continuuity/loom/http/LoomService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.continuuity.loom.http.handler;
+package com.continuuity.loom.http;
 
 import com.continuuity.http.HttpHandler;
 import com.continuuity.http.NettyHttpService;

--- a/server/src/main/java/com/continuuity/loom/http/handler/LoomAdminHandler.java
+++ b/server/src/main/java/com/continuuity/loom/http/handler/LoomAdminHandler.java
@@ -558,68 +558,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
   }
 
   /**
-   * Delete a specific {@link ProviderType}. User must be admin or a 403 is returned.
-   *
-   * @param request The request to delete a provider type.
-   * @param responder Responder for sending the response.
-   * @param providertypeId Id of the provider type to delete.
-   */
-  @DELETE
-  @Path("/providertypes/{providertype-id}")
-  public void deleteProviderType(HttpRequest request, HttpResponder responder,
-                                 @PathParam("providertype-id") String providertypeId) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isSuperadmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
-      return;
-    }
-
-    try {
-      entityStoreService.getView(account).deleteProviderType(providertypeId);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (IOException e) {
-      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                          "Exception deleting provider type " + providertypeId);
-    } catch (IllegalAccessException e) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to delete provider type.");
-    }
-  }
-
-  /**
-   * Delete a specific {@link AutomatorType}. User must be admin or a 403 is returned.
-   *
-   * @param request The request to delete an automator type.
-   * @param responder Responder for sending the response.
-   * @param automatortypeId Id of the automator type to delete.
-   */
-  @DELETE
-  @Path("/automatortypes/{automatortype-id}")
-  public void deleteAutomatorType(HttpRequest request, HttpResponder responder,
-                                 @PathParam("automatortype-id") String automatortypeId) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isSuperadmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
-      return;
-    }
-
-    try {
-      entityStoreService.getView(account).deleteAutomatorType(automatortypeId);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (IOException e) {
-      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                          "Exception deleting automator type " + automatortypeId);
-    } catch (IllegalAccessException e) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to delete automator type.");
-    }
-  }
-
-  /**
    * Writes a {@link Provider}. User must be admin or a 403 is returned. If the name in the path does not match the
    * name in the put body, a 400 is returned.
    *
@@ -820,88 +758,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
                           "Exception writing cluster template " + clustertemplateId);
     } catch (IllegalAccessException e) {
       responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to write cluster template.");
-    }
-  }
-
-  /**
-   * Writes a {@link ProviderType}. User must be admin or a 403 is returned.
-   * If the name in the path does not match the name in the put body, a 400 is returned.
-   *
-   * @param request Request to write provider type.
-   * @param responder Responder to send response.
-   * @param providertypeId Id of the provider type to write.
-   */
-  @PUT
-  @Path("/providertypes/{providertype-id}")
-  public void putProviderType(HttpRequest request, HttpResponder responder,
-                              @PathParam("providertype-id") String providertypeId) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isSuperadmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
-      return;
-    }
-
-    ProviderType providerType = getEntityFromRequest(request, responder, ProviderType.class);
-    if (providerType == null) {
-      // getEntityFromRequest writes to the responder if there was an issue.
-      return;
-    } else if (!providerType.getName().equals(providertypeId)) {
-      responder.sendError(HttpResponseStatus.BAD_REQUEST, "mismatch between provider type name and name in path.");
-      return;
-    }
-
-    try {
-      entityStoreService.getView(account).writeProviderType(providerType);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (IOException e) {
-      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                          "Exception writing provider type " + providertypeId);
-    } catch (IllegalAccessException e) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to write provider type.");
-    }
-  }
-
-  /**
-   * Writes a {@link AutomatorType}. User must be admin or a 403 is returned.
-   * If the name in the path does not match the name in the put body, a 400 is returned.
-   *
-   * @param request Request to write provider type.
-   * @param responder Responder to send response.
-   * @param automatortypeId Id of the provider type to write.
-   */
-  @PUT
-  @Path("/automatortypes/{automatortype-id}")
-  public void putAutomatorType(HttpRequest request, HttpResponder responder,
-                               @PathParam("automatortype-id") String automatortypeId) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isSuperadmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
-      return;
-    }
-
-    AutomatorType automatorType = getEntityFromRequest(request, responder, AutomatorType.class);
-    if (automatorType == null) {
-      // getEntityFromRequest writes to the responder if there was an issue.
-      return;
-    } else if (!automatorType.getName().equals(automatortypeId)) {
-      responder.sendError(HttpResponseStatus.BAD_REQUEST, "mismatch between automator type name and name in path.");
-      return;
-    }
-
-    try {
-      entityStoreService.getView(account).writeAutomatorType(automatorType);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (IOException e) {
-      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                          "Exception writing automator type " + automatortypeId);
-    } catch (IllegalAccessException e) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to write automator type.");
     }
   }
 
@@ -1140,14 +996,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
     LOG.debug("Exporting {} cluster templates", clusterTemplates.size());
     outJson.put(CLUSTER_TEMPLATES, gson.toJsonTree(clusterTemplates));
 
-    Collection<AutomatorType> automatorTypes = view.getAllAutomatorTypes();
-    LOG.debug("Exporting {} automator types", automatorTypes.size());
-    outJson.put(AUTOMATOR_TYPES, gson.toJsonTree(automatorTypes));
-
-    Collection<ProviderType> providerTypes = view.getAllProviderTypes();
-    LOG.debug("Exporting {} provider types", providerTypes.size());
-    outJson.put(PROVIDER_TYPES, gson.toJsonTree(providerTypes));
-
     LOG.trace("Exporting {}", outJson);
 
     responder.sendJson(HttpResponseStatus.OK, outJson);
@@ -1208,16 +1056,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
         gson.<List<ClusterTemplate>>fromJson(inJson.get(CLUSTER_TEMPLATES),
                                                         new TypeToken<List<ClusterTemplate>>() {}.getType());
 
-      newAutomatorTypes = !inJson.containsKey(AUTOMATOR_TYPES) ?
-        ImmutableList.<AutomatorType>of() :
-        gson.<List<AutomatorType>>fromJson(inJson.get(AUTOMATOR_TYPES),
-                                           new TypeToken<List<AutomatorType>>() {}.getType());
-
-      newProviderTypes = !inJson.containsKey(PROVIDER_TYPES) ?
-        ImmutableList.<ProviderType>of() :
-        gson.<List<ProviderType>>fromJson(inJson.get(PROVIDER_TYPES),
-                                          new TypeToken<List<ProviderType>>() {}.getType());
-
 
     } catch (JsonSyntaxException e) {
       LOG.error("Got exception while importing config", e);
@@ -1248,14 +1086,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
         view.deleteClusterTemplate(clusterTemplate.getName());
       }
 
-      for (AutomatorType automatorType : view.getAllAutomatorTypes()) {
-        view.deleteAutomatorType(automatorType.getName());
-      }
-
-      for (ProviderType providerType : view.getAllProviderTypes()) {
-        view.deleteProviderType(providerType.getName());
-      }
-
       // Add new config data
       LOG.debug("Importing {} providers", newProviders.size());
       for (Provider provider : newProviders) {
@@ -1280,16 +1110,6 @@ public class LoomAdminHandler extends LoomAuthHandler {
       LOG.debug("Importing {} cluster templates", newClusterTemplates.size());
       for (ClusterTemplate clusterTemplate : newClusterTemplates) {
         view.writeClusterTemplate(clusterTemplate);
-      }
-
-      LOG.debug("Importing {} automator types", newAutomatorTypes.size());
-      for (AutomatorType automatorType : newAutomatorTypes) {
-        view.writeAutomatorType(automatorType);
-      }
-
-      LOG.debug("Importing {} provider types", newProviderTypes.size());
-      for (ProviderType providerType : newProviderTypes) {
-        view.writeProviderType(providerType);
       }
 
       LOG.debug("Importing {} cluster templates", newClusterTemplates.size());

--- a/server/src/main/java/com/continuuity/loom/http/handler/LoomAdminHandler.java
+++ b/server/src/main/java/com/continuuity/loom/http/handler/LoomAdminHandler.java
@@ -572,8 +572,8 @@ public class LoomAdminHandler extends LoomAuthHandler {
     if (account == null) {
       return;
     }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be admin.");
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
       return;
     }
 
@@ -603,8 +603,8 @@ public class LoomAdminHandler extends LoomAuthHandler {
     if (account == null) {
       return;
     }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be admin.");
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
       return;
     }
 
@@ -839,8 +839,8 @@ public class LoomAdminHandler extends LoomAuthHandler {
     if (account == null) {
       return;
     }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be admin.");
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
       return;
     }
 
@@ -880,8 +880,8 @@ public class LoomAdminHandler extends LoomAuthHandler {
     if (account == null) {
       return;
     }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be admin.");
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
       return;
     }
 

--- a/server/src/main/java/com/continuuity/loom/http/handler/LoomSuperadminHandler.java
+++ b/server/src/main/java/com/continuuity/loom/http/handler/LoomSuperadminHandler.java
@@ -17,10 +17,13 @@ package com.continuuity.loom.http.handler;
 
 import com.continuuity.http.HttpResponder;
 import com.continuuity.loom.account.Account;
+import com.continuuity.loom.admin.AutomatorType;
+import com.continuuity.loom.admin.ProviderType;
 import com.continuuity.loom.admin.Tenant;
 import com.continuuity.loom.provisioner.CapacityException;
 import com.continuuity.loom.provisioner.Provisioner;
 import com.continuuity.loom.provisioner.TenantProvisionerService;
+import com.continuuity.loom.store.entity.EntityStoreService;
 import com.continuuity.loom.store.tenant.TenantStore;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -41,6 +44,7 @@ import javax.ws.rs.PathParam;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.reflect.Type;
 import java.util.UUID;
 
 /**
@@ -51,12 +55,15 @@ public class LoomSuperadminHandler extends LoomAuthHandler {
   private static final Logger LOG  = LoggerFactory.getLogger(LoomSuperadminHandler.class);
 
   private final Gson gson;
+  private final EntityStoreService entityStoreService;
   private final TenantProvisionerService tenantProvisionerService;
 
   @Inject
-  private LoomSuperadminHandler(TenantStore store, TenantProvisionerService tenantProvisionerService, Gson gson) {
+  private LoomSuperadminHandler(TenantStore store, TenantProvisionerService tenantProvisionerService,
+                                EntityStoreService entityStoreService, Gson gson) {
     super(store);
     this.gson = gson;
+    this.entityStoreService = entityStoreService;
     this.tenantProvisionerService = tenantProvisionerService;
   }
 
@@ -313,5 +320,169 @@ public class LoomSuperadminHandler extends LoomAuthHandler {
       LOG.error("Exception while getting provisioners", e);
       responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Exception while getting provisioners");
     }
+  }
+  /**
+   * Delete a specific {@link com.continuuity.loom.admin.ProviderType}. User must be admin or a 403 is returned.
+   *
+   * @param request The request to delete a provider type.
+   * @param responder Responder for sending the response.
+   * @param providertypeId Id of the provider type to delete.
+   */
+  @DELETE
+  @Path("/loom/providertypes/{providertype-id}")
+  public void deleteProviderType(HttpRequest request, HttpResponder responder,
+                                 @PathParam("providertype-id") String providertypeId) {
+    Account account = getAndAuthenticateAccount(request, responder);
+    if (account == null) {
+      return;
+    }
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
+      return;
+    }
+
+    try {
+      entityStoreService.getView(account).deleteProviderType(providertypeId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IOException e) {
+      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                          "Exception deleting provider type " + providertypeId);
+    } catch (IllegalAccessException e) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to delete provider type.");
+    }
+  }
+
+  /**
+   * Delete a specific {@link com.continuuity.loom.admin.AutomatorType}. User must be admin or a 403 is returned.
+   *
+   * @param request The request to delete an automator type.
+   * @param responder Responder for sending the response.
+   * @param automatortypeId Id of the automator type to delete.
+   */
+  @DELETE
+  @Path("/loom/automatortypes/{automatortype-id}")
+  public void deleteAutomatorType(HttpRequest request, HttpResponder responder,
+                                  @PathParam("automatortype-id") String automatortypeId) {
+    Account account = getAndAuthenticateAccount(request, responder);
+    if (account == null) {
+      return;
+    }
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
+      return;
+    }
+
+    try {
+      entityStoreService.getView(account).deleteAutomatorType(automatortypeId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IOException e) {
+      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                          "Exception deleting automator type " + automatortypeId);
+    } catch (IllegalAccessException e) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to delete automator type.");
+    }
+  }
+
+  /**
+   * Writes a {@link com.continuuity.loom.admin.ProviderType}. User must be admin or a 403 is returned.
+   * If the name in the path does not match the name in the put body, a 400 is returned.
+   *
+   * @param request Request to write provider type.
+   * @param responder Responder to send response.
+   * @param providertypeId Id of the provider type to write.
+   */
+  @PUT
+  @Path("/loom/providertypes/{providertype-id}")
+  public void putProviderType(HttpRequest request, HttpResponder responder,
+                              @PathParam("providertype-id") String providertypeId) {
+    Account account = getAndAuthenticateAccount(request, responder);
+    if (account == null) {
+      return;
+    }
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
+      return;
+    }
+
+    ProviderType providerType = getEntityFromRequest(request, responder, ProviderType.class);
+    if (providerType == null) {
+      // getEntityFromRequest writes to the responder if there was an issue.
+      return;
+    } else if (!providerType.getName().equals(providertypeId)) {
+      responder.sendError(HttpResponseStatus.BAD_REQUEST, "mismatch between provider type name and name in path.");
+      return;
+    }
+
+    try {
+      entityStoreService.getView(account).writeProviderType(providerType);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IOException e) {
+      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                          "Exception writing provider type " + providertypeId);
+    } catch (IllegalAccessException e) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to write provider type.");
+    }
+  }
+
+  /**
+   * Writes a {@link com.continuuity.loom.admin.AutomatorType}. User must be admin or a 403 is returned.
+   * If the name in the path does not match the name in the put body, a 400 is returned.
+   *
+   * @param request Request to write provider type.
+   * @param responder Responder to send response.
+   * @param automatortypeId Id of the provider type to write.
+   */
+  @PUT
+  @Path("/loom/automatortypes/{automatortype-id}")
+  public void putAutomatorType(HttpRequest request, HttpResponder responder,
+                               @PathParam("automatortype-id") String automatortypeId) {
+    Account account = getAndAuthenticateAccount(request, responder);
+    if (account == null) {
+      return;
+    }
+    if (!account.isSuperadmin()) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized, must be superadmin.");
+      return;
+    }
+
+    AutomatorType automatorType = getEntityFromRequest(request, responder, AutomatorType.class);
+    if (automatorType == null) {
+      // getEntityFromRequest writes to the responder if there was an issue.
+      return;
+    } else if (!automatorType.getName().equals(automatortypeId)) {
+      responder.sendError(HttpResponseStatus.BAD_REQUEST, "mismatch between automator type name and name in path.");
+      return;
+    }
+
+    try {
+      entityStoreService.getView(account).writeAutomatorType(automatorType);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IOException e) {
+      responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                          "Exception writing automator type " + automatortypeId);
+    } catch (IllegalAccessException e) {
+      responder.sendError(HttpResponseStatus.FORBIDDEN, "user unauthorized to write automator type.");
+    }
+  }
+
+  private <T> T getEntityFromRequest(HttpRequest request, HttpResponder responder, Type tClass) {
+    T result = null;
+    try {
+      Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
+      try {
+        result = gson.fromJson(reader, tClass);
+      } finally {
+        try {
+          reader.close();
+        } catch (IOException e) {
+          LOG.warn("Exception while closing request reader", e);
+        }
+      }
+    } catch (IllegalArgumentException e) {
+      responder.sendError(HttpResponseStatus.BAD_REQUEST, "invalid input: " + e.getMessage());
+    } catch (Exception e) {
+      responder.sendError(HttpResponseStatus.BAD_REQUEST, "invalid input");
+    }
+    return result;
   }
 }

--- a/server/src/main/java/com/continuuity/loom/runtime/LoomServerMain.java
+++ b/server/src/main/java/com/continuuity/loom/runtime/LoomServerMain.java
@@ -24,7 +24,7 @@ import com.continuuity.loom.common.queue.guice.QueueModule;
 import com.continuuity.loom.common.zookeeper.IdService;
 import com.continuuity.loom.common.zookeeper.guice.ZookeeperModule;
 import com.continuuity.loom.http.guice.HttpModule;
-import com.continuuity.loom.http.handler.LoomService;
+import com.continuuity.loom.http.LoomService;
 import com.continuuity.loom.management.LoomStats;
 import com.continuuity.loom.management.guice.ManagementModule;
 import com.continuuity.loom.provisioner.guice.ProvisionerModule;

--- a/server/src/main/java/com/continuuity/loom/store/entity/BaseSQLEntityStoreView.java
+++ b/server/src/main/java/com/continuuity/loom/store/entity/BaseSQLEntityStoreView.java
@@ -112,18 +112,14 @@ public abstract class BaseSQLEntityStoreView extends BaseEntityStoreView {
     queryStr.append(entityTypeId);
     queryStr.append(" FROM ");
     queryStr.append(entityTypeId);
-    queryStr.append("s WHERE name=? AND ");
+    queryStr.append("s WHERE name=? AND tenant_id=?");
     // TODO: remove once types are defined through server instead of through provisioner
-    if (entityType == EntityType.AUTOMATOR_TYPE || entityType == EntityType.PROVIDER_TYPE) {
-      queryStr.append("( tenant_id=? OR tenant_id='");
-      queryStr.append(Constants.SUPERADMIN_TENANT);
-      queryStr.append("' )");
-    } else {
-      queryStr.append(" tenant_id=?");
-    }
+    // automator and provider types are constant across tenants and defined only in the superadmin tenant.
+    String tenantId = (entityType == EntityType.AUTOMATOR_TYPE || entityType == EntityType.PROVIDER_TYPE) ?
+      Constants.SUPERADMIN_TENANT : account.getTenantId();
     PreparedStatement statement = conn.prepareStatement(queryStr.toString());
     statement.setString(1, entityName);
-    statement.setString(2, account.getTenantId());
+    statement.setString(2, tenantId);
     return statement;
   }
 
@@ -137,14 +133,12 @@ public abstract class BaseSQLEntityStoreView extends BaseEntityStoreView {
     queryStr.append(entityTypeId);
     queryStr.append("s WHERE tenant_id=? ");
     // TODO: remove once types are defined through server instead of through provisioner
-    if (entityType == EntityType.AUTOMATOR_TYPE || entityType == EntityType.PROVIDER_TYPE) {
-      queryStr.append(" OR tenant_id='");
-      queryStr.append(Constants.SUPERADMIN_TENANT);
-      queryStr.append("'");
-    }
+    // automator and provider types are constant across tenants and defined only in the superadmin tenant.
+    String tenantId = (entityType == EntityType.AUTOMATOR_TYPE || entityType == EntityType.PROVIDER_TYPE) ?
+      Constants.SUPERADMIN_TENANT : account.getTenantId();
 
     PreparedStatement statement = conn.prepareStatement(queryStr.toString());
-    statement.setString(1, account.getTenantId());
+    statement.setString(1, tenantId);
     return statement;
   }
 }

--- a/server/src/main/java/com/continuuity/loom/store/entity/SQLAdminEntityStoreView.java
+++ b/server/src/main/java/com/continuuity/loom/store/entity/SQLAdminEntityStoreView.java
@@ -34,7 +34,7 @@ public class SQLAdminEntityStoreView extends BaseSQLEntityStoreView {
 
   SQLAdminEntityStoreView(Account account, DBConnectionPool dbConnectionPool, Gson gson) {
     super(account, dbConnectionPool, gson);
-    Preconditions.checkArgument(account.isAdmin(), "Entity store only viewable by admins");
+    Preconditions.checkArgument(account.isAdmin(), "Entity store only writeable by admins");
   }
 
   @Override

--- a/server/src/test/java/com/continuuity/loom/http/LoomClusterHandlerTest.java
+++ b/server/src/test/java/com/continuuity/loom/http/LoomClusterHandlerTest.java
@@ -1587,27 +1587,28 @@ public class LoomClusterHandlerTest extends LoomServiceTestBase {
                                          new Compatibilities(null, null, ImmutableSet.of("zookeeper")),
                                          null, new Administration(new LeaseDuration(10000, 30000, 5000)));
 
-    EntityStoreView entityStore = entityStoreService.getView(ADMIN_ACCOUNT);
+    EntityStoreView adminView = entityStoreService.getView(ADMIN_ACCOUNT);
+    EntityStoreView superadminView = entityStoreService.getView(SUPERADMIN_ACCOUNT);
+    superadminView.writeProviderType(Entities.ProviderTypeExample.JOYENT);
     // create providers
-    entityStore.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
+    adminView.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
                                            ImmutableMap.<String, String>of()));
-    entityStore.writeProviderType(Entities.ProviderTypeExample.JOYENT);
     // create hardware types
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "medium",
         "medium hardware",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Medium 4GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-mem",
         "hardware with a lot of memory",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Large 32GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-cpu",
         "hardware with a lot of cpu",
@@ -1615,21 +1616,22 @@ public class LoomClusterHandlerTest extends LoomServiceTestBase {
       )
     );
     // create image types
-    entityStore.writeImageType(
+    adminView.writeImageType(
       new ImageType(
         "centos6",
         "CentOs 6.4 image",
-        ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("image", "joyent-hash-of-centos6.4"))
+        ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("image",
+                                                                                               "joyent-hash-of-centos6.4"))
       )
     );
     // create services
     for (String serviceName : services) {
-      entityStore.writeService(new Service(
+      adminView.writeService(new Service(
         serviceName, serviceName + " description", Collections.<String>emptySet(),
         Collections.<ProvisionerAction, ServiceAction>emptyMap()));
     }
-    entityStore.writeClusterTemplate(reactorTemplate);
-    entityStore.writeClusterTemplate(smallTemplate);
+    adminView.writeClusterTemplate(reactorTemplate);
+    adminView.writeClusterTemplate(smallTemplate);
   }
 
   private static final String SAMPLE_PLAN =

--- a/server/src/test/java/com/continuuity/loom/http/LoomServiceTestBase.java
+++ b/server/src/test/java/com/continuuity/loom/http/LoomServiceTestBase.java
@@ -21,7 +21,7 @@ import com.continuuity.loom.admin.Tenant;
 import com.continuuity.loom.common.conf.Constants;
 import com.continuuity.loom.common.queue.QueueGroup;
 import com.continuuity.loom.common.queue.internal.ElementsTrackingQueue;
-import com.continuuity.loom.http.handler.LoomService;
+import com.continuuity.loom.http.LoomService;
 import com.continuuity.loom.scheduler.JobScheduler;
 import com.continuuity.loom.scheduler.Scheduler;
 import com.google.inject.Key;
@@ -50,6 +50,7 @@ public class LoomServiceTestBase extends BaseTest {
   protected static final String TENANT = "tenant1";
   protected static final Account USER1_ACCOUNT = new Account(USER1, TENANT);
   protected static final Account ADMIN_ACCOUNT = new Account(Constants.ADMIN_USER, TENANT);
+  protected static final Account SUPERADMIN_ACCOUNT = new Account(Constants.ADMIN_USER, Constants.SUPERADMIN_TENANT);
   protected static final Header[] USER1_HEADERS = {
     new BasicHeader(Constants.USER_HEADER, USER1),
     new BasicHeader(Constants.API_KEY_HEADER, API_KEY),

--- a/server/src/test/java/com/continuuity/loom/layout/BaseSolverTest.java
+++ b/server/src/test/java/com/continuuity/loom/layout/BaseSolverTest.java
@@ -107,33 +107,33 @@ public class BaseSolverTest extends BaseTest {
     );
     reactorTemplate2 = gson.fromJson(Entities.ClusterTemplateExample.REACTOR2_STRING, ClusterTemplate.class);
 
-    EntityStoreView entityStore = entityStoreService.getView(account);
+    EntityStoreView adminView = entityStoreService.getView(account);
     // create providers
-    entityStore.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
+    adminView.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
                                            ImmutableMap.<String, String>of()));
     // create hardware types
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "small",
         "small hardware",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Small 2GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "medium",
         "medium hardware",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Medium 4GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-mem",
         "hardware with a lot of memory",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Large 32GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-cpu",
         "hardware with a lot of cpu",
@@ -141,7 +141,7 @@ public class BaseSolverTest extends BaseTest {
       )
     );
     // create image types
-    entityStore.writeImageType(
+    adminView.writeImageType(
       new ImageType(
         "centos6",
         "CentOS 6.4 image",
@@ -149,7 +149,7 @@ public class BaseSolverTest extends BaseTest {
           "joyent", ImmutableMap.<String, String>of("image", "joyent-hash-of-centos6.4"))
       )
     );
-    entityStore.writeImageType(
+    adminView.writeImageType(
       new ImageType(
         "ubuntu12",
         "Ubuntu 12 image",
@@ -186,18 +186,20 @@ public class BaseSolverTest extends BaseTest {
     serviceMap.put(reactor.getName(), reactor);
     serviceMap.put(mysql.getName(), mysql);
 
-    entityStore.writeService(namenode);
-    entityStore.writeService(datanode);
-    entityStore.writeService(resourcemanager);
-    entityStore.writeService(nodemanager);
-    entityStore.writeService(hbasemaster);
-    entityStore.writeService(regionserver);
-    entityStore.writeService(zookeeper);
-    entityStore.writeService(reactor);
-    entityStore.writeService(mysql);
-    entityStore.writeClusterTemplate(reactorTemplate);
+    adminView.writeService(namenode);
+    adminView.writeService(datanode);
+    adminView.writeService(resourcemanager);
+    adminView.writeService(nodemanager);
+    adminView.writeService(hbasemaster);
+    adminView.writeService(regionserver);
+    adminView.writeService(zookeeper);
+    adminView.writeService(reactor);
+    adminView.writeService(mysql);
+    adminView.writeClusterTemplate(reactorTemplate);
 
-    entityStore.writeProviderType(Entities.ProviderTypeExample.JOYENT);
-    entityStore.writeProviderType(Entities.ProviderTypeExample.RACKSPACE);
+    EntityStoreView superadminView =
+      entityStoreService.getView(new Account(Constants.ADMIN_USER, Constants.SUPERADMIN_TENANT));
+    superadminView.writeProviderType(Entities.ProviderTypeExample.JOYENT);
+    superadminView.writeProviderType(Entities.ProviderTypeExample.RACKSPACE);
   }
 }

--- a/server/src/test/java/com/continuuity/loom/scheduler/SchedulerTest.java
+++ b/server/src/test/java/com/continuuity/loom/scheduler/SchedulerTest.java
@@ -24,7 +24,7 @@ import com.continuuity.loom.common.queue.Element;
 import com.continuuity.loom.common.queue.QueueGroup;
 import com.continuuity.loom.common.queue.TrackingQueue;
 import com.continuuity.loom.common.zookeeper.IdService;
-import com.continuuity.loom.http.handler.LoomService;
+import com.continuuity.loom.http.LoomService;
 import com.continuuity.loom.scheduler.callback.CallbackData;
 import com.continuuity.loom.scheduler.task.ClusterJob;
 import com.continuuity.loom.scheduler.task.ClusterTask;

--- a/server/src/test/java/com/continuuity/loom/scheduler/SolverSchedulerTest.java
+++ b/server/src/test/java/com/continuuity/loom/scheduler/SolverSchedulerTest.java
@@ -168,27 +168,30 @@ public class SolverSchedulerTest extends BaseTest {
       null
     );
 
-    EntityStoreView entityStore = entityStoreService.getView(account);
+    EntityStoreView superadminView =
+      entityStoreService.getView(new Account(Constants.ADMIN_USER, Constants.SUPERADMIN_TENANT));
+    superadminView.writeProviderType(Entities.ProviderTypeExample.JOYENT);
+
+    EntityStoreView adminView = entityStoreService.getView(account);
     // create providers
-    entityStore.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
+    adminView.writeProvider(new Provider("joyent", "joyent provider", Entities.JOYENT,
                                            ImmutableMap.<String, String>of()));
-    entityStore.writeProviderType(Entities.ProviderTypeExample.JOYENT);
     // create hardware types
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "medium",
         "medium hardware",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Medium 4GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-mem",
         "hardware with a lot of memory",
         ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("flavor", "Large 32GB"))
       )
     );
-    entityStore.writeHardwareType(
+    adminView.writeHardwareType(
       new HardwareType(
         "large-cpu",
         "hardware with a lot of cpu",
@@ -196,18 +199,19 @@ public class SolverSchedulerTest extends BaseTest {
       )
     );
     // create image types
-    entityStore.writeImageType(
+    adminView.writeImageType(
       new ImageType(
         "centos6",
         "CentOs 6.4 image",
-        ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("image", "joyent-hash-of-centos6.4"))
+        ImmutableMap.<String, Map<String, String>>of("joyent", ImmutableMap.<String, String>of("image",
+                                                                                               "joyent-hash-of-centos6.4"))
       )
     );
     // create services
     for (String serviceName : services) {
-      entityStore.writeService(new Service(serviceName, serviceName + " description", ImmutableSet.<String>of(),
+      adminView.writeService(new Service(serviceName, serviceName + " description", ImmutableSet.<String>of(),
                                            ImmutableMap.<ProvisionerAction, ServiceAction>of()));
     }
-    entityStore.writeClusterTemplate(reactorTemplate);
+    adminView.writeClusterTemplate(reactorTemplate);
   }
 }


### PR DESCRIPTION
writeable by the superadmin only. This is because plugins are
currently constant across all tenants, but will change once that
is no longer the case.
