### PR TITLE
some test cleanup. Dont instantiate a scheduler to make sure it

### DIFF
--- a/server/src/test/java/com/continuuity/loom/BaseTest.java
+++ b/server/src/test/java/com/continuuity/loom/BaseTest.java
@@ -45,7 +45,10 @@ import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.util.Modules;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.apache.twill.zookeeper.RetryStrategies;
 import org.apache.twill.zookeeper.ZKClientService;
+import org.apache.twill.zookeeper.ZKClientServices;
+import org.apache.twill.zookeeper.ZKClients;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -53,6 +56,7 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Base class with utilities for loading admin entities into a entityStore and starting zookeeper up.
@@ -83,15 +87,24 @@ public class BaseTest {
     zkServer = InMemoryZKServer.builder().setDataDir(tmpFolder.newFolder()).setTickTime(5000).build();
     zkServer.startAndWait();
 
-    zkClientService = ZKClientService.Builder.of(zkServer.getConnectionStr()).build();
-    zkClientService.startAndWait();
-
     conf = Configuration.create();
     conf.set(Constants.PORT, "0");
     conf.set(Constants.HOST, HOSTNAME);
     conf.set(Constants.SCHEDULER_INTERVAL_SECS, "1");
     conf.set(Constants.JDBC_DRIVER, "org.apache.derby.jdbc.EmbeddedDriver");
     conf.set(Constants.JDBC_CONNECTION_STRING, "jdbc:derby:memory:loom;create=true");
+
+    zkClientService = ZKClientServices.delegate(
+      ZKClients.reWatchOnExpire(
+        ZKClients.retryOnFailure(
+          ZKClientService.Builder.of(zkServer.getConnectionStr())
+            .setSessionTimeout(conf.getInt(Constants.ZOOKEEPER_SESSION_TIMEOUT_MILLIS))
+            .build(),
+          RetryStrategies.fixDelay(2, TimeUnit.SECONDS)
+        )
+      )
+    );
+    zkClientService.startAndWait();
 
     mockClusterCallback = new MockClusterCallback();
     injector = Guice.createInjector(

--- a/server/src/test/java/com/continuuity/loom/http/LoomServiceTestBase.java
+++ b/server/src/test/java/com/continuuity/loom/http/LoomServiceTestBase.java
@@ -82,7 +82,6 @@ public class LoomServiceTestBase extends BaseTest {
   protected static QueueGroup solverQueues;
   protected static QueueGroup jobQueues;
   protected static QueueGroup callbackQueues;
-  protected static Scheduler scheduler;
   protected static TenantProvisionerService tenantProvisionerService;
 
 
@@ -98,8 +97,6 @@ public class LoomServiceTestBase extends BaseTest {
     loomService = injector.getInstance(LoomService.class);
     loomService.startAndWait();
     port = loomService.getBindAddress().getPort();
-    scheduler = injector.getInstance(Scheduler.class);
-    scheduler.startAndWait();
     tenantProvisionerService = injector.getInstance(TenantProvisionerService.class);
     tenantStore.writeTenant(new Tenant("name", TENANT_ID, 10, 100, 1000));
   }
@@ -113,7 +110,6 @@ public class LoomServiceTestBase extends BaseTest {
   @AfterClass
   public static void cleanupServiceBase() {
     loomService.stopAndWait();
-    scheduler.stopAndWait();
   }
 
   public static HttpResponse doGet(String resource) throws Exception {

--- a/server/src/test/java/com/continuuity/loom/scheduler/SchedulerTest.java
+++ b/server/src/test/java/com/continuuity/loom/scheduler/SchedulerTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Multiset;
 import com.google.gson.JsonObject;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,38 +55,11 @@ import java.util.concurrent.TimeUnit;
  * Test ClusterScheduler
  */
 public class SchedulerTest extends LoomServiceTestBase {
-  private static QueueGroup clusterQueues;
-  private static QueueGroup provisionerQueues;
-  private static QueueGroup callbackQueues;
-  private static QueueGroup solverQueues;
-  private static QueueGroup jobQueues;
-  private static LoomService loomService;
   private static Cluster cluster;
   private static ClusterJob job;
 
-  @BeforeClass
-  public static void start() throws Exception {
-    injector.getInstance(IdService.class).startAndWait();
-
-    clusterQueues = injector.getInstance(Key.get(QueueGroup.class, Names.named(Constants.Queue.CLUSTER)));
-    provisionerQueues = injector.getInstance(Key.get(QueueGroup.class, Names.named(Constants.Queue.PROVISIONER)));
-    solverQueues = injector.getInstance(Key.get(QueueGroup.class, Names.named(Constants.Queue.SOLVER)));
-    jobQueues = injector.getInstance(Key.get(QueueGroup.class, Names.named(Constants.Queue.JOB)));
-    callbackQueues = injector.getInstance(Key.get(QueueGroup.class, Names.named(Constants.Queue.CALLBACK)));
-
-    loomService = injector.getInstance(LoomService.class);
-    loomService.startAndWait();
-  }
-
   @Before
   public void beforeTest() throws Exception {
-    jobQueues.removeAll();
-    clusterQueues.removeAll();
-    solverQueues.removeAll();
-    provisionerQueues.removeAll();
-    callbackQueues.removeAll();
-    mockClusterCallback.clear();
-
     cluster = Entities.ClusterExample.createCluster();
     job = new ClusterJob(new JobId(cluster.getId(), 0), ClusterAction.CLUSTER_CREATE);
     cluster.setLatestJobId(job.getJobId());
@@ -94,6 +68,16 @@ public class SchedulerTest extends LoomServiceTestBase {
 
     clusterStore.writeNode(Entities.ClusterExample.NODE1);
     clusterStore.writeNode(Entities.ClusterExample.NODE2);
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    jobQueues.removeAll();
+    clusterQueues.removeAll();
+    solverQueues.removeAll();
+    provisionerQueues.removeAll();
+    callbackQueues.removeAll();
+    mockClusterCallback.clear();
   }
 
   @Test(timeout = 20000)


### PR DESCRIPTION
does not start the schedulers and cause non deterministic
behavior. Also making zookeeper client retry for convenience when
debugging tests so that they dont fail when you set breakpoints
due to connection timeouts.
