### PR TITLE
internal provisioner api will be trusted when security is added,

### DIFF
--- a/server/src/main/java/com/continuuity/loom/http/handler/LoomProvisionerHandler.java
+++ b/server/src/main/java/com/continuuity/loom/http/handler/LoomProvisionerHandler.java
@@ -183,26 +183,21 @@ public final class LoomProvisionerHandler extends LoomAuthHandler {
    *
    * @param request Request to get an automator type resource
    * @param responder Responder for responding to the request
+   * @param tenantId Id of the tenant that owns the resource
    * @param automatortypeId Id of the automator type that owns the resource
    * @param resourceType Type of resource to get
    * @param name Name of the resource to get
    * @param version Version of the resource to get
    */
   @GET
-  @Path("/loom/automatortypes/{automatortype-id}/{resource-type}/{resource-name}/versions/{version}")
+  @Path("/tenants/{tenant-id}/automatortypes/{automatortype-id}/{type}/{name}/versions/{version}")
   public void getAutomatorResource(HttpRequest request, HttpResponder responder,
+                                   @PathParam("tenant-id") String tenantId,
                                    @PathParam("automatortype-id") String automatortypeId,
-                                   @PathParam("resource-type") String resourceType,
-                                   @PathParam("resource-name") String name,
+                                   @PathParam("type") String resourceType,
+                                   @PathParam("name") String name,
                                    @PathParam("version") String version) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "User must be admin.");
-      return;
-    }
+    Account account = new Account(Constants.ADMIN_USER, tenantId);
 
     ResourceType resourceTypeObj = new ResourceType(PluginType.AUTOMATOR, automatortypeId, resourceType);
     sendResourceInChunks(responder, account, resourceTypeObj, name, version);
@@ -213,26 +208,21 @@ public final class LoomProvisionerHandler extends LoomAuthHandler {
    *
    * @param request Request to get an provider type resource
    * @param responder Responder for responding to the request
+   * @param tenantId Id of the tenant that owns the resource
    * @param providertypeId Id of the provider type that owns the resource
    * @param resourceType Type of resource to get
    * @param name Name of the resource to get
    * @param version Version of the resource to get
    */
   @GET
-  @Path("/loom/providertypes/{providertype-id}/{resource-type}/{resource-name}/versions/{version}")
-  public void deleteProviderTypeModuleVersion(HttpRequest request, HttpResponder responder,
-                                              @PathParam("providertype-id") String providertypeId,
-                                              @PathParam("resource-type") String resourceType,
-                                              @PathParam("resource-name") String name,
-                                              @PathParam("version") String version) {
-    Account account = getAndAuthenticateAccount(request, responder);
-    if (account == null) {
-      return;
-    }
-    if (!account.isAdmin()) {
-      responder.sendError(HttpResponseStatus.FORBIDDEN, "User must be admin.");
-      return;
-    }
+  @Path("/tenants/{tenant-id}/providertypes/{providertype-id}/{type}/{name}/versions/{version}")
+  public void getProviderTypeResource(HttpRequest request, HttpResponder responder,
+                                      @PathParam("tenant-id") String tenantId,
+                                      @PathParam("providertype-id") String providertypeId,
+                                      @PathParam("type") String resourceType,
+                                      @PathParam("name") String name,
+                                      @PathParam("version") String version) {
+    Account account = new Account(Constants.ADMIN_USER, tenantId);
 
     ResourceType resourceTypeObj = new ResourceType(PluginType.PROVIDER, providertypeId, resourceType);
     sendResourceInChunks(responder, account, resourceTypeObj, name, version);

--- a/server/src/test/java/com/continuuity/loom/http/LoomPluginHandlerTest.java
+++ b/server/src/test/java/com/continuuity/loom/http/LoomPluginHandlerTest.java
@@ -53,8 +53,6 @@ public class LoomPluginHandlerTest extends LoomServiceTestBase {
     assertResponseStatus(doPost(getNamePath(type2, "name"), "contents", USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
     assertResponseStatus(doDelete(getVersionedPath(type1, meta), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
     assertResponseStatus(doDelete(getVersionedPath(type2, meta), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
-    assertResponseStatus(doGet(getVersionedPath(type1, meta), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
-    assertResponseStatus(doGet(getVersionedPath(type2, meta), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
     assertResponseStatus(doGet(getNamePath(type1, "name"), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
     assertResponseStatus(doGet(getNamePath(type2, "name"), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
     assertResponseStatus(doGet(getTypePath(type1), USER1_HEADERS), HttpResponseStatus.FORBIDDEN);
@@ -110,8 +108,20 @@ public class LoomPluginHandlerTest extends LoomServiceTestBase {
     HttpResponse response = doGet(getNamePath(pluginResourceType, meta.getName()), ADMIN_HEADERS);
     assertResponseStatus(response, HttpResponseStatus.OK);
     Assert.assertEquals(ImmutableSet.of(meta), bodyToMetaSet(response));
+
     // get actual contents
-    response = doGet(getVersionedPath(pluginResourceType, meta), ADMIN_HEADERS);
+    String typeStr = type.name().toLowerCase() + "types";
+    String path = Joiner.on('/').join(
+      "/v1/tenants",
+      ADMIN_ACCOUNT.getTenantId(),
+      typeStr,
+      pluginName,
+      resourceType,
+      meta.getName(),
+      "versions",
+      meta.getVersion()
+    );
+    response = doGet(path);
     assertResponseStatus(response, HttpResponseStatus.OK);
     Assert.assertEquals(contents, bodyToString(response));
   }


### PR DESCRIPTION
should not be authenticating with an api key and provisioners
should be able to get any tenant resource they needed. Thus,
moving tenant id into the path.
