### PR TITLE
Remove ALL RIGHTS RESERVED from footer. Fixes #123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Continuuity Loom CHANGELOG
 Unreleased
 ----------
 - MongoDB support for clusters ( Issues: #43 #130 )
+- Remove 'ALL RIGHTS RESERVED' footer ( Issues: #123 #340 )
 - Ruby testing with rspec/rubocop ( Issues: #128 #132 #133 )
 - Nginx support for clusters ( Issues: #131 #323 )
 - Sensu monitoring support ( Issues: #167 )

--- a/ui/client/templates/login.html
+++ b/ui/client/templates/login.html
@@ -88,7 +88,7 @@
       </div>
     </div>
   {% endblock %}
-  <div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC. ALL RIGHTS RESERVED.</span><br>
+  <div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC.</span><br>
 
     <a href="http://www.continuuity.com/terms-and-privacy" id="footer-terms" target="blank">Terms and Privacy</a>
     <span>&nbsp;·&nbsp;</`span>

--- a/ui/client/templates/partials/footer.html
+++ b/ui/client/templates/partials/footer.html
@@ -1,4 +1,4 @@
-<div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC. ALL RIGHTS RESERVED.</span><br>
+<div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC.</span><br>
 
   <a href="http://www.continuuity.com/terms-and-privacy" id="footer-terms" target="blank">Terms and Privacy</a>
   <span>&nbsp;·&nbsp;</span>

--- a/ui/client/templates/user/index.html
+++ b/ui/client/templates/user/index.html
@@ -50,7 +50,7 @@
     {% include "partials/notification-div.html" %}
   {% block content %}
   {% endblock %}
-  <div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC. ALL RIGHTS RESERVED.</span><br>
+  <div id="footer" style="clear: both;"><span id="copyright">COPYRIGHT © 2014 CONTINUUITY INC.</span><br>
 
     <a href="http://www.continuuity.com/terms-and-privacy" id="footer-terms" target="blank">Terms and Privacy</a>
     <span>&nbsp;·&nbsp;</span>


### PR DESCRIPTION
We use the Apache License, v2.0... I have removed the 'ALL RIGHTS RESERVED' link, but am unsure if we should link to the [Apache License](http://www.apache.org/licenses/LICENSE-2.0.html), instead.
