### PR TITLE
Mount data disk on Rackspace

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -102,7 +102,7 @@ class FogProviderRackspace < Provider
       # Validate connectivity and Mount data disk
       Net::SSH.start(@result['result']['ipaddress'], @task['config']['ssh-auth']['user'], @credentials) do |ssh|
         ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
-        ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde
+        ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde1 /data) || true")
       end
       # Return 0
       @result['status'] = 0

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -95,13 +95,14 @@ class FogProviderRackspace < Provider
       wait_for_sshd(bootstrap_ip, 22)
       log.debug "Server #{server.name} sshd is up"
 
-      # Process results
       @result['result']['ipaddress'] = bootstrap_ip
-      # Additional checks
+      # do we need sudo bash?
+      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
-      # Validate connectivity
+      # Validate connectivity and Mount data disk
       Net::SSH.start(@result['result']['ipaddress'], @task['config']['ssh-auth']['user'], @credentials) do |ssh|
         ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde
       end
       # Return 0
       @result['status'] = 0


### PR DESCRIPTION
This checks for the presence of `/dev/xvde1` which is where Rackspace mounts larger data disks on their performance line of hardware types. This takes that disk and mounts it into `/data` so that it is usable.
