### PR TITLE
Feature/provisioner init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Unreleased
 - Bootstrap a tenant ( Issues: #304 )
 - Allow non-root users for SSH ( Issues: #314 #320 )
 - PHP module support ( Issues: #317 )
+- Standalone build updates for multitenancy ( Issues #349 )
 
 v0.9.7 (May 27, 2014)
 ---------------------

--- a/bin/loom-provisioner.sh
+++ b/bin/loom-provisioner.sh
@@ -61,7 +61,8 @@ start ( ) {
 
 register ( ) {
   echo "Registering provisioner plugins with configured server"
-  nice -1 ${LOOM_RUBY} ${PROVISIONER_PATH}/bin/provisioner --config ${PROVISIONER_PATH}/conf/provisioner-site.xml --register
+  nice -1 ${LOOM_RUBY} ${PROVISIONER_PATH}/bin/provisioner --config ${PROVISIONER_PATH}/conf/provisioner-site.xml --register \
+    >> ${LOOM_LOG_DIR}/${APP_NAME}.log 2>&1 &
 }
 
 stop ( ) {

--- a/bin/loom-provisioner.sh
+++ b/bin/loom-provisioner.sh
@@ -61,7 +61,7 @@ start ( ) {
 
 register ( ) {
   echo "Registering provisioner plugins with configured server"
-  nice -1 ${LOOM_RUBY} ${PROVISIONER_PATH}/provisioner.rb --config ${PROVISIONER_PATH}/conf/provisioner-site.xml --register
+  nice -1 ${LOOM_RUBY} ${PROVISIONER_PATH}/bin/provisioner --config ${PROVISIONER_PATH}/conf/provisioner-site.xml --register
 }
 
 stop ( ) {

--- a/bin/loom-provisioner.sh
+++ b/bin/loom-provisioner.sh
@@ -106,14 +106,14 @@ status() {
     pidToCheck=`cat $pid`
     if kill -0 $pidToCheck > /dev/null 2>&1; then
       echo "${APP_NAME} running as process $pidToCheck"
-      ret=0
+      return 0
     else
       echo "${APP_NAME} pidfile exists, but process does not appear to be running"
-      ret=3
+      return 3
     fi
   else
     echo "${APP_NAME} is not running"
-    ret=2
+    return 2
   fi
 }
 

--- a/standalone/assembly/standalone.xml
+++ b/standalone/assembly/standalone.xml
@@ -7,8 +7,8 @@
     <baseDirectory>loom-${project.version}-standalone</baseDirectory>
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/../provisioner/daemon</directory>
-            <outputDirectory>/provisioner/daemon</outputDirectory>
+            <directory>${project.basedir}/../provisioner</directory>
+            <outputDirectory>/provisioner</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../ui</directory>

--- a/standalone/assembly/standalone.xml
+++ b/standalone/assembly/standalone.xml
@@ -47,6 +47,10 @@
     </fileSets>
         <files>
             <file>
+                <source>${project.basedir}/../standalone/provisioner/master/conf/provisioner-site.xml</source>
+                <outputDirectory>/provisioner/master/conf</outputDirectory>
+            </file>
+            <file>
                 <source>${project.basedir}/../standalone/README.md</source>
                 <outputDirectory>/</outputDirectory>
             </file>

--- a/standalone/bin/loom.sh
+++ b/standalone/bin/loom.sh
@@ -17,6 +17,10 @@ export LOOM_NODE=${LOOM_NODE:-node}
 # Provisioner environment
 export LOOM_RUBY=${LOOM_RUBY:-ruby}
 export LOOM_USE_DUMMY_PROVISIONER=${LOOM_USE_DUMMY_PROVISIONER:-false}
+export LOOM_API_USER=${LOOM_API_USER:-admin}
+export LOOM_TENANT=${LOOM_TENANT:-superadmin}
+export LOOM_NUM_WORKERS=${LOOM_NUM_WORKERS:-5}
+
 
 APP_NAME="loom-standalone"
 APP_BASE_NAME=`basename "$0"`
@@ -161,18 +165,14 @@ function request_superadmin_workers () {
 
     wait_for_provisioner
 
-    echo "Requesting 5 workers for default tenant..."
-    # set the initial number of workers for the superadmin tenant
-    #--header "X-Loom-UserID:${LOOM_API_USER}" \
-    #--header "X-Loom-TenantID:${LOOM_TENANT}" \
+    echo "Requesting ${LOOM_NUM_WORKERS} workers for default tenant..."
     curl --silent --request PUT \
       --header "Content-Type:application/json" \
-      --header "X-Loom-UserID:admin" \
-      --header "X-Loom-TenantID:superadmin" \
-      --connect-timeout 5 --data '{"workers":5, "name":"superadmin"}' \
+      --header "X-Loom-UserID:${LOOM_API_USER}" \
+      --header "X-Loom-TenantID:${LOOM_TENANT}" \
+      --connect-timeout 5 --data "{\"workers\":${LOOM_NUM_WORKERS}, \"name\":\"superadmin\"}" \
       http://localhost:55054/v1/tenants/superadmin
 }
-
 
 function wait_for_server () {
     RETRIES=0

--- a/standalone/bin/loom.sh
+++ b/standalone/bin/loom.sh
@@ -199,13 +199,13 @@ function wait_for_provisioner () {
 }
 
 function provisioner () {
+    if [ "x$1" == "xstart" ]
+    then
+        echo "Waiting for server to start before running provisioner..."
+        wait_for_server
+    fi
     if [ "x${LOOM_USE_DUMMY_PROVISIONER}" == "xtrue" ] 
     then
-        if [ "x$1" == "xstart" ]
-        then
-            echo "Waiting for server to start before running dummy provisioner..."
-            wait_for_server
-        fi
         $LOOM_HOME/bin/loom-dummy-provisioner.sh $1 
     else
         $LOOM_HOME/bin/loom-provisioner.sh $1
@@ -234,9 +234,12 @@ case "$1" in
   ;;
 
   restart)
-    $LOOM_HOME/bin/loom-server.sh restart
-    $LOOM_HOME/bin/loom-ui.sh restart
-    provisioner restart
+    provisioner stop
+    $LOOM_HOME/bin/loom-ui.sh stop
+    $LOOM_HOME/bin/loom-server.sh stop
+    $LOOM_HOME/bin/loom-server.sh start
+    $LOOM_HOME/bin/loom-ui.sh start
+    provisioner start
   ;;
 
   status)

--- a/standalone/bin/loom.sh
+++ b/standalone/bin/loom.sh
@@ -178,7 +178,7 @@ function wait_for_server () {
     RETRIES=0
     until [[ $(curl http://localhost:55054/status 2> /dev/null | grep OK) || $RETRIES -gt 60 ]]; do
         sleep 2
-        RETRIES=$[$RETRIES + 1]
+        ((RETRIES++))
     done
 
     if [ $RETRIES -gt 60 ]; then
@@ -190,7 +190,7 @@ function wait_for_provisioner () {
     RETRIES=0
     until [[ $(curl http://localhost:55056/status 2> /dev/null | grep OK) || $RETRIES -gt 60 ]]; do
         sleep 2
-        RETRIES=$[$RETRIES + 1]
+        ((RETRIES++))
     done
 
     if [ $RETRIES -gt 60 ]; then

--- a/standalone/provisioner/master/conf/provisioner-site.xml
+++ b/standalone/provisioner/master/conf/provisioner-site.xml
@@ -1,0 +1,8 @@
+<configuration>
+  <property>
+    <name>provisioner.register.ip</name>
+    <value>127.0.0.1</value>
+    <description>Routable IP for the server to call back to this provisioner</description>
+  </property>
+</configuration>
+


### PR DESCRIPTION
this PR makes standalone build on develop branch work:
- [x] necessary init scripts for provisioner master
- [x] necessary changes to the orchestration of bringing up loom standalone - ensure server is always running before provisioner starts or stops (for register/unregister).  restart is now an ordered stop then start of components.  registration is split into more granular functions.  
- [x] standalone-specific provisioner-site.xml and maven changes to put it in place
- [x] as before, provisioner (now master and workers) are logging to stdout, which all gets redirected to a single log.  I plan to add some additional header fields to the logging to help distinguish between different workers/tenants/etc.

```
mac[17:53:57] derek:bin (feature/provisioner-init)$ ./loom.sh start
Starting Loom Server ...
Starting Loom UI ...
Waiting for server to start before loading default configuration...
Loading default configuration...
Registering provisioner plugins with configured server
Waiting for server to start before running provisioner...
Starting Loom Provisioner ...
Requesting 5 workers for default tenant...

Go to http://localhost:8100. Have fun creating clusters!
```
