### PR TITLE
Check number of arguments to ssh_exec and do the right thing

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -92,7 +92,14 @@ class FogProviderOpenstack < Provider
       set_credentials(@task['config']['ssh-auth'])
       # Validate connectivity
       Net::SSH.start(@result['result']['ipaddress'], @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        # Backwards-compatibility... ssh_exec! takes 2 arguments prior to 0.9.8
+        ssho = method(:ssh_exec!)
+        if ssho.arity == 2
+          log.debug 'Validating external connectivity and DNS resolution via ping'
+          ssh_exec!(ssh, 'ping -c1 www.opscode.com')
+        else
+          ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        end
       end
       # Return 0
       @result['status'] = 0

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -101,7 +101,14 @@ class FogProviderRackspace < Provider
       set_credentials(@task['config']['ssh-auth'])
       # Validate connectivity
       Net::SSH.start(@result['result']['ipaddress'], @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        # Backwards-compatibility... ssh_exec! takes 2 arguments prior to 0.9.8
+        ssho = method(:ssh_exec!)
+        if ssho.arity == 2
+          log.debug 'Validating external connectivity and DNS resolution via ping'
+          ssh_exec!(ssh, 'ping -c1 www.opscode.com')
+        else
+          ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        end
       end
       # Return 0
       @result['status'] = 0


### PR DESCRIPTION
This allows the `fog_provisioner` to be used on older versions of Loom, such as the 0.9.7 standalone...
