### PR TITLE
Feature/issue 313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Unreleased
 - Settable max for clusters and nodes in a tenant ( Issues: #302 )
 - Bootstrap a tenant ( Issues: #304 )
 - Larger HW: xlarge, xxlarge ( Issues: #312 #346 )
+- SSH hangs on some providers ( Issues: #313 #351 )
 - Allow non-root users for SSH ( Issues: #314 #320 )
 - PHP module support ( Issues: #317 )
 - Standalone build updates for multitenancy ( Issues #349 )

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -99,7 +99,6 @@ class FogProviderAWS < Provider
       end
       bind_ip = server.private_ip_address
 
-      sleep 30
       wait_for_sshd(bootstrap_ip, 22)
       log.debug "Server #{server.id} sshd is up"
 

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/utils.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/utils.rb
@@ -59,6 +59,8 @@ module FogProvider
     ssh_test_max = 10*60
     ssh_test = 0
     log.debug 'Waiting for sshd'
+    # Initial sleep, to prevent getting caught by provider firewall rules
+    sleep 30
     begin
       until tcp_test_port(host, port)
         if ssh_test < ssh_test_max


### PR DESCRIPTION
This fixes #313 for AWS/Joyent... it seems that these providers have some default DROP firewall, so initial TCP connections to the host hang until TCP's default timeout.
