### PR TITLE
Feature/standalone startup race

### DIFF
--- a/provisioner/master/lib/provisioner/api.rb
+++ b/provisioner/master/lib/provisioner/api.rb
@@ -35,7 +35,7 @@ module Loom
       set :environment, :production
 
       get '/status' do
-        body "OK"
+        body settings.provisioner.status
       end
 
       get '/heartbeat' do

--- a/provisioner/master/lib/provisioner/provisioner.rb
+++ b/provisioner/master/lib/provisioner/provisioner.rb
@@ -90,6 +90,8 @@ module Loom
       spawn_heartbeat_thread
       # spawn the signal handler thread
       spawn_signal_thread
+      # announce we are started up
+      @status = 'OK'
 
       # wait for signal_handler to exit in response to signals
       @signal_thread.join
@@ -298,6 +300,11 @@ module Loom
         hb['usage'][id] = tm.num_workers
       end
       hb
+    end
+
+    # get current status
+    def status
+      @status ||= 'UNKNOWN'
     end
 
     # determine ip to register with server from routing info

--- a/provisioner/master/lib/provisioner/provisioner.rb
+++ b/provisioner/master/lib/provisioner/provisioner.rb
@@ -48,6 +48,7 @@ module Loom
       host = Socket.gethostname.downcase
       @provisioner_id = "#{host}.#{pid}"
       log.info "provisioner #{@provisioner_id} initialized"
+      @registered = false
     end
 
     # invoked from bin/provisioner
@@ -80,6 +81,7 @@ module Loom
 
     # main run block
     def run
+      @status = 'STARTING'
       # start the api server
       spawn_sinatra_thread
       # wait for sinatra to fully initialize
@@ -90,8 +92,8 @@ module Loom
       spawn_heartbeat_thread
       # spawn the signal handler thread
       spawn_signal_thread
-      # announce we are started up
-      @status = 'OK'
+
+      # heartbeat thread will update status to 'OK'
 
       # wait for signal_handler to exit in response to signals
       @signal_thread.join
@@ -167,8 +169,8 @@ module Loom
     def spawn_heartbeat_thread
       @heartbeat_thread = Thread.new {
         log.info "starting heartbeat thread"
-        register_with_server
         loop {
+          register_with_server unless @registered
           uri = "#{@server_uri}/v1/provisioners/#{provisioner_id}/heartbeat"
           begin
             json = heartbeat.to_json
@@ -205,6 +207,9 @@ module Loom
         resp = RestClient.put("#{uri}", data.to_json, :'X-Loom-UserID' => "admin")
         if(resp.code == 200)
           log.info "Successfully registered"
+          @registered = true
+          # announce provisioner is ready
+          @status = 'OK'
         else
           log.warn "Response code #{resp.code}, #{resp.to_str} when registering with loom server #{uri}"
         end


### PR DESCRIPTION
fixes a race condition in standalone startup:

```
Starting Loom Provisioner ...
Requesting 5 workers for default tenant...
Not enough capacity to update tenant.
```

this was because the status check used by wait_for_provisioner returns OK as soon as API is up, which could be before the heartbeat thread registers with the server.
- [x] make the /status call meaningful, returns status as updated during startup procedure
- [x] heartbeat thread now tracks once there is a successful registration, sets status, and will continuallly retry upon startup.  this should allow provisioner be started up before server.
