### PR TITLE
Feature/standalone data directories

### DIFF
--- a/standalone/bin/loom.sh
+++ b/standalone/bin/loom.sh
@@ -66,6 +66,7 @@ export PID_DIR=/var/tmp
 export LOOM_HOME=$APP_HOME
 export LOOM_SERVER_HOME=$APP_HOME/server
 export LOOM_SERVER_CONF=$LOOM_HOME/server/conf/
+export LOOM_PROVISIONER_CONF=$LOOM_HOME/provisioner/master/conf
 export LOOM_LOG_DIR=$LOOM_HOME/logs
 export LOOM_DATA_DIR=$LOOM_HOME/data
 
@@ -81,6 +82,7 @@ mkdir -p $LOOM_LOG_DIR || die "Could not create dir $LOOM_LOG_DIR: $!"
 mkdir -p $LOOM_DATA_DIR || die "Could not create dir $LOOM_DATA_DIR: $!"
 SED_LOOM_DATA_DIR=`echo $LOOM_DATA_DIR | sed 's:/:\\\/:g'`
 sed -i.old "s/LOOM_DATA_DIR/$SED_LOOM_DATA_DIR/g" $LOOM_SERVER_CONF/loom-site.xml
+sed -i.old "s/LOOM_DATA_DIR/$SED_LOOM_DATA_DIR/g" $LOOM_PROVISIONER_CONF/provisioner-site.xml
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/standalone/provisioner/master/conf/provisioner-site.xml
+++ b/standalone/provisioner/master/conf/provisioner-site.xml
@@ -4,5 +4,15 @@
     <value>127.0.0.1</value>
     <description>Routable IP for the server to call back to this provisioner</description>
   </property>
+  <property>
+    <name>provisioner.data.dir</name>
+    <value>LOOM_DATA_DIR/provisioner/data</value>
+    <description>Provisioner storage directory for plugin data resources</description>
+  </property>
+  <property>
+    <name>provisioner.work.dir</name>
+    <value>LOOM_DATA_DIR/provisioner/work</value>
+    <description>Provisioner working directory</description>
+  </property>
 </configuration>
 

--- a/standalone/server/conf/loom-site.xml
+++ b/standalone/server/conf/loom-site.xml
@@ -6,4 +6,9 @@
     <name>server.local.data.dir</name>
     <value>LOOM_DATA_DIR</value>
   </property>
+  <property>
+    <name>server.plugin.store.localfilestore.data.dir</name>
+    <value>LOOM_DATA_DIR/plugins/resources</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
additional standalone config to keep all data in its local `./data` dir instead of /var/loom...
- [x] added `server.plugin.store.localfilestore.data.dir` to server config template
- [x] applied the startup sed to the `provisioner-site.xml` as well, and added data/work dir settings to it 
