### PR TITLE
add rest_client requirement

### DIFF
--- a/standalone/README.md
+++ b/standalone/README.md
@@ -10,6 +10,7 @@ Install
 sudo gem install fog --version 1.21.0
 sudo gem install sinatra --version 1.4.5
 sudo gem install thin --version 1.6.2
+sudo gem install rest_client --version 1.7.3
 
 Start
 =====


### PR DESCRIPTION
provisioner requires rest_client gem, which used to be pulled in by one of the other deps
