### PR TITLE
Feature/standalone sync bundled data

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+TIMEOUT=3
+LOOM_HOME=${LOOM_HOME:-/opt/loom}
+LOOM_SERVER_URI=${LOOM_SERVER_URI:-http://localhost:55054}
+LOOM_API_USER=${LOOM_API_USER:-admin}
+LOOM_API_KEY=${LOOM_API_KEY:-1234567890abcdef}
+LOOM_TENANT=${LOOM_TENANT:-superadmin}
+CHEF_SOLO_DIR=${LOOM_HOME}/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator
+
+LOOM_RUBY=${LOOM_RUBY:-ruby}
+DATA_UPLOADER="${LOOM_RUBY} ${LOOM_HOME}/bin/data-uploader.rb"
+
+COOKBOOKS_DIR=${CHEF_SOLO_DIR}/cookbooks
+ROLES_DIR=${CHEF_SOLO_DIR}/roles
+DATA_BAGS_DIR=${CHEF_SOLO_DIR}/data_bags
+
+# load cookbooks
+cd ${COOKBOOKS_DIR}
+for d in $(ls -p -1 | grep "/$" | sed "s,/$,,") ; do
+  ${DATA_UPLOADER} --quiet --uri ${LOOM_SERVER_URI} --tenant ${LOOM_TENANT} \
+    --user ${LOOM_API_USER} stage ${d} automatortypes/chef-solo/cookbooks/${d}
+  ret=$?
+  [[ ${ret} -ne 0 ]] && failed="${failed} ${d}"
+done
+[[ ${failed} ]] && echo "Failed to load cookbook: ${failed}" && exit 1
+
+# load data_bags
+cd ${DATA_BAGS_DIR}
+for d in $(ls -p -1 | grep "/$" | sed "s,/$,,") ; do
+  ${DATA_UPLOADER} --quiet --uri ${LOOM_SERVER_URI} --tenant ${LOOM_TENANT} \
+    --user ${LOOM_API_USER} stage ${d} automatortypes/chef-solo/data_bags/${d}
+  ret=$?
+  [[ ${ret} -ne 0 ]] && failed="${failed} ${d}"
+done
+[[ ${failed} ]] && echo "Failed to load data_bag: ${failed}" && exit 1
+
+# load roles
+cd ${ROLES_DIR}
+for f in $(ls -1 {*.rb,*.json} 2>/dev/null) ; do
+  ${DATA_UPLOADER} --quiet --uri ${LOOM_SERVER_URI} --tenant ${LOOM_TENANT} \
+    --user ${LOOM_API_USER} stage ${f} automatortypes/chef-solo/roles/${f}
+  ret=$?
+  [[ ${ret} -ne 0 ]] && failed="${failed} ${f}"
+done
+[[ ${failed} ]] && echo "Failed to load role: ${failed}" && exit 1


### PR DESCRIPTION
depends on #382 
- [x] loom.sh standalone startup script will now source any `load-bundled-data.sh` included at plugin top-level.  these scripts can use the common data-uploader.rb to do the actual work.  
- [x] load-bundled-data.sh included here for chef-solo, shell coming next
- [x] loom.sh waits and confirms plugin registration, stages all data, then does a sync

```
$ time ./loom.sh start
Starting Loom Server ...
Starting Loom UI ...
Waiting for server to start before loading default configuration...
Loading default configuration...
Registering provisioner plugins with configured server
Waiting for plugins to be registered...
Loading initial data...
Syncing initial data...
Waiting for server to start before running provisioner...
Starting Loom Provisioner ...
Requesting 5 workers for default tenant...

Go to http://localhost:8100. Have fun creating clusters!

real    0m32.520s
user    0m17.531s
sys 0m2.270s
```
