### PR TITLE
Feature/data tar fix

### DIFF
--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -252,7 +252,7 @@ module Loom
         path_dir = File.dirname(path)
         path_base = File.basename(path)
         Gem::Package::TarWriter.new(tarfile) do |tar|
-          Dir[File.join(path_dir, "#{path_base}/**/*")].each do |file|
+          Dir[path, File.join(path_dir, "#{path_base}/**/*")].each do |file|
             mode = File.stat(file).mode
             relative_file = file.sub(/^#{Regexp.escape path_dir}\/?/, '')
 

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -249,11 +249,12 @@ module Loom
       # is the contents of the tar file.
       def tar_with_resourcename(path)
         tarfile = StringIO.new('')
+        path_dir = File.dirname(path)
+        path_base = File.basename(path)
         Gem::Package::TarWriter.new(tarfile) do |tar|
-          Dir[File.join(path, '**/*')].each do |file|
+          Dir[File.join(path_dir, "#{path_base}/**/*")].each do |file|
             mode = File.stat(file).mode
-            relative_file = file.sub(/^#{Regexp.escape path}\/?/, '')
-            relative_file = File.join(@options[:resource_name], relative_file)
+            relative_file = file.sub(/^#{Regexp.escape path_dir}\/?/, '')
 
             if File.directory?(file)
               tar.mkdir relative_file, mode

--- a/provisioner/master/lib/provisioner/resourcemanager.rb
+++ b/provisioner/master/lib/provisioner/resourcemanager.rb
@@ -119,6 +119,10 @@ module Loom
             if entry.directory?
               FileUtils.mkdir_p dest, :mode => entry.header.mode
             elsif entry.file?
+              # ensure extraction directory exists
+              d_dir = File.dirname(dest)
+              FileUtils.mkdir_p d_dir unless File.exist? d_dir
+
               File.open dest, 'wb' do |f|
                 f.print entry.read
               end


### PR DESCRIPTION
fix issues related to tarring and untarring.
- [x] the tar creation in data-uploader was incorrectly setting the parent dir on entries, and was also not creating an explicit entry for just this parent dir (ie, top-level 'hadoop')
- [x] in the provisioner, attempt to workaround this problem if it ever happens (shouldn't)
