### PR TITLE
dnssuffix field in createcluster advanced section 

### DIFF
--- a/ui/client/js/user/createcluster.js
+++ b/ui/client/js/user/createcluster.js
@@ -186,6 +186,11 @@ CreateCluster.app.controller('CreateClusterCtrl', ['$scope', '$interval', 'dataF
       services: $scope.selectedServices,
       initialLeaseDuration: $scope.leaseDuration.initial
     };
+
+    if ($scope.dnsSuffix) {
+      postJson.dnsSuffix = $scope.dnsSuffix;
+    }
+
     if ($scope.defaultConfig) {
       if (!Helpers.isValidJSON($scope.defaultConfig)) {
         $scope.notification = Helpers.JSON_ERR;

--- a/ui/client/templates/user/clusters/createcluster.html
+++ b/ui/client/templates/user/clusters/createcluster.html
@@ -79,6 +79,14 @@
                   </table>
                 </div>
               </div>
+
+              <div class="form-group" ng-hide="clusterId">
+                <label for="inputProvider" class="col-sm-2 control-label">DNS suffix</label>
+                <div class="col-sm-5">
+                  <input type="text" class="form-control" ng-model="dnsSuffix"/>
+                </div>
+              </div>
+
               <div class="form-group">
                 <label for="inputProvider" class="col-sm-2 control-label">Provider</label>
                 <div class="col-sm-8">


### PR DESCRIPTION
fixes #52

the field will be hidden in the cluster-reconfigure view.
