### PR TITLE
Feature/use data dir

### DIFF
--- a/config/defaults/clustertemplates/hadoop-distributed.json
+++ b/config/defaults/clustertemplates/hadoop-distributed.json
@@ -18,7 +18,8 @@
     "config": {
       "hadoop": {
         "core_site": {
-          "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%"
+          "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%",
+          "hadoop.tmp.dir": "/data"
         },
         "hdfs_site": {
           "dfs.datanode.max.transfer.threads": "4096",

--- a/config/defaults/clustertemplates/hadoop-distributed.json
+++ b/config/defaults/clustertemplates/hadoop-distributed.json
@@ -19,7 +19,7 @@
       "hadoop": {
         "core_site": {
           "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%",
-          "hadoop.tmp.dir": "/data"
+          "hadoop.tmp.dir": "/data/hadoop"
         },
         "hdfs_site": {
           "dfs.datanode.max.transfer.threads": "4096",
@@ -58,6 +58,12 @@
         "server_debian_password": "somedefaultpassword",
         "server_root_password": "somedefaultpassword",
         "server_repl_password": "somedefaultpassword",
+        "data_dir": "/data/mysql",
+        "server": {
+          "directories": {
+            "log_dir": "/data/mysql",
+          }
+        },
         "bind_address": "%ip.bind_v4.service.mysql-server%"
       }
     }

--- a/config/defaults/clustertemplates/hadoop-singlenode.json
+++ b/config/defaults/clustertemplates/hadoop-singlenode.json
@@ -58,6 +58,12 @@
         "server_debian_password": "somedefaultpassword",
         "server_root_password": "somedefaultpassword",
         "server_repl_password": "somedefaultpassword",
+        "data_dir": "/data/mysql",
+        "server": {
+          "directories": {
+            "log_dir": "/data/mysql",
+          }
+        },
         "bind_address": "%ip.bind_v4.service.mysql-server%"
       }
     }

--- a/config/defaults/clustertemplates/hadoop-singlenode.json
+++ b/config/defaults/clustertemplates/hadoop-singlenode.json
@@ -18,7 +18,8 @@
     "config": {
       "hadoop": {
         "core_site": {
-          "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%"
+          "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%",
+          "hadoop.tmp.dir": "/data"
         },
         "hdfs_site": {
           "dfs.datanode.max.transfer.threads": "4096",

--- a/config/defaults/clustertemplates/hadoop-singlenode.json
+++ b/config/defaults/clustertemplates/hadoop-singlenode.json
@@ -19,7 +19,7 @@
       "hadoop": {
         "core_site": {
           "fs.defaultFS": "hdfs://%host.service.hadoop-hdfs-namenode%",
-          "hadoop.tmp.dir": "/data"
+          "hadoop.tmp.dir": "/data/hadoop"
         },
         "hdfs_site": {
           "dfs.datanode.max.transfer.threads": "4096",

--- a/config/defaults/clustertemplates/lamp.json
+++ b/config/defaults/clustertemplates/lamp.json
@@ -42,6 +42,12 @@
         "server_debian_password": "somedefaultpassword",
         "server_root_password": "somedefaultpassword",
         "server_repl_password": "somedefaultpassword",
+        "data_dir": "/data/mysql",
+        "server": {
+          "directories": {
+            "log_dir": "/data/mysql",
+          }
+        },
         "bind_address": "%ip.bind_v4.service.mysql-server%"
       },
       "php": {

--- a/config/defaults/clustertemplates/mongodb-singlenode.json
+++ b/config/defaults/clustertemplates/mongodb-singlenode.json
@@ -12,7 +12,8 @@
     "config": {
       "mongodb": {
         "config": {
-          "bind_ip": "%ip.bind_v4.service.mongodb-single%"
+          "bind_ip": "%ip.bind_v4.service.mongodb-single%",
+          "dbpath": "/data/mongodb"
         }
       }
     }


### PR DESCRIPTION
Most providers give us secondary data disks, which we are mounting to `/data`. This tells our templates to use this location for data.
