### PR TITLE
Feature/mapred history server

### DIFF
--- a/config/defaults/clustertemplates/hadoop-distributed.json
+++ b/config/defaults/clustertemplates/hadoop-distributed.json
@@ -85,6 +85,7 @@
       "hadoop-hdfs-datanode",
       "hadoop-yarn-resourcemanager",
       "hadoop-yarn-nodemanager",
+      "hadoop-mapreduce-historyserver",
       "zookeeper-server",
       "hbase-master",
       "hbase-regionserver",
@@ -108,6 +109,7 @@
         [
           "hadoop-hdfs-namenode",
           "hadoop-yarn-resourcemanager",
+          "hadoop-mapreduce-historyserver",
           "hbase-master",
           "mysql-server",
           "hive-metastore-database",
@@ -130,6 +132,12 @@
         }
       },
       "hadoop-yarn-resourcemanager": {
+        "quantities": {
+          "min": "1",
+          "max": "1"
+        }
+      },
+      "hadoop-mapreduce-historyserver": {
         "quantities": {
           "min": "1",
           "max": "1"

--- a/config/defaults/clustertemplates/hadoop-singlenode.json
+++ b/config/defaults/clustertemplates/hadoop-singlenode.json
@@ -84,6 +84,7 @@
       "hadoop-hdfs-datanode",
       "hadoop-yarn-resourcemanager",
       "hadoop-yarn-nodemanager",
+      "hadoop-mapreduce-historyserver",
       "zookeeper-server",
       "hbase-master",
       "hbase-regionserver",

--- a/config/defaults/services/hadoop-mapreduce-historyserver.json
+++ b/config/defaults/services/hadoop-mapreduce-historyserver.json
@@ -1,0 +1,49 @@
+{
+  "name": "hadoop-mapreduce-historyserver",
+  "description": "Hadoop MapReduce History Server",
+  "dependencies": {
+    "conflicts": [],
+    "install": {
+      "requires": [ "base" ],
+      "uses": [ "kerberos-client" ]
+    },
+    "provides": [],
+    "runtime": {
+      "requires": [],
+      "uses": [
+        "kerberos-master",
+        "hadoop-yarn-resourcemanager"
+      ]
+    }
+  },
+  "provisioner": {
+    "actions": {
+      "install": {
+        "type":"chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop::hadoop_mapreduce_historyserver]"
+        }
+      },
+      "configure": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::default]"
+        }
+      },
+      "start": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_mapreduce_historyserver],recipe[loom_service_runner::default]",
+          "json_attributes": "{\"loom\": { \"node\": { \"services\": { \"hadoop-mapreduce-historyserver\": \"start\" } } } }" 
+        }
+      },
+      "stop": {
+        "type": "chef-solo",
+        "fields": {
+          "run_list": "recipe[hadoop_wrapper::default],recipe[hadoop::hadoop_mapreduce_historyserver],recipe[loom_service_runner::default]",
+          "json_attributes": "{\"loom\": { \"node\": { \"services\": { \"hadoop-mapreduce-historyserver\": \"stop\" } } } }" 
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a `hadoop-mapreduce-historyserver` service and adds it to the compatibility for `hadoop-singlenode` and `hadoop-distributed` clustertemplates.
