### PR TITLE
Server expects the provisioner fields in a hardware type to be

### DIFF
--- a/config/defaults/hardwaretypes/standard-large.json
+++ b/config/defaults/hardwaretypes/standard-large.json
@@ -5,57 +5,39 @@
     "aws-us-east-1": {
       "flavor": "m1.large",
       "cost": "0.175",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "7.5",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420"
-        }
-      }
+      "vcpu": "2",
+      "ram": "7.5",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420"
     },
     "aws-us-west-1": {
       "flavor": "m1.large",
       "cost": "0.175",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "7.5",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420"
-        }
-      }
+      "vcpu": "2",
+      "ram": "7.5",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420"
     },
     "aws-us-west-2": {
       "flavor": "m1.large",
       "cost": "0.175",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "7.5",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420"
-        }
-      }
+      "vcpu": "2",
+      "ram": "7.5",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420"
     },
     "joyent": {
       "flavor": "g3-standard-7.5-kvm",
       "cost": "0.24",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "7.5",
-        "disks": {
-          "/dev/vdb": "738"
-        }
-      }
+      "vcpu": "2",
+      "ram": "7.5",
+      "disk_/dev/vdb": "738"
     },
     "rackspace": {
       "flavor": "6",
       "cost": "0.60",
-      "hardware": {
-        "vcpu": "4",
-        "ram": "8"
-      }
+      "vcpu": "4",
+      "ram": "8"
     }
   }
 }

--- a/config/defaults/hardwaretypes/standard-large.json
+++ b/config/defaults/hardwaretypes/standard-large.json
@@ -7,31 +7,28 @@
       "cost": "0.175",
       "vcpu": "2",
       "ram": "7.5",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420"
     },
     "aws-us-west-1": {
       "flavor": "m1.large",
       "cost": "0.175",
       "vcpu": "2",
       "ram": "7.5",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420"
     },
     "aws-us-west-2": {
       "flavor": "m1.large",
       "cost": "0.175",
       "vcpu": "2",
       "ram": "7.5",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420"
     },
     "joyent": {
       "flavor": "g3-standard-7.5-kvm",
       "cost": "0.24",
       "vcpu": "2",
       "ram": "7.5",
-      "disk_/dev/vdb": "738"
+      "disks": "/dev/vdb=738"
     },
     "rackspace": {
       "flavor": "6",

--- a/config/defaults/hardwaretypes/standard-medium.json
+++ b/config/defaults/hardwaretypes/standard-medium.json
@@ -7,28 +7,28 @@
       "cost": "0.087",
       "vcpu": "1",
       "ram": "3.75",
-      "disk_/dev/xvdb": "410"
+      "disks": "/dev/xvdb=410"
     },
     "aws-us-west-1": {
       "flavor": "m1.medium",
       "cost": "0.087",
       "vcpu": "1",
       "ram": "3.75",
-      "disk_/dev/xvdb": "410"
+      "disks": "/dev/xvdb=410"
     },
     "aws-us-west-2": {
       "flavor": "m1.medium",
       "cost": "0.087",
       "vcpu": "1",
       "ram": "3.75",
-      "disk_/dev/xvdb": "410"
+      "disks": "/dev/xvdb=410"
     },
     "joyent": {
       "flavor": "g3-standard-3.75-kvm",
       "cost": "0.12",
       "vcpu": "1",
       "ram": "3.75",
-      "disk_/dev/vdb": "123"
+      "disks": "/dev/vdb=123"
     },
     "rackspace": {
       "flavor": "5",

--- a/config/defaults/hardwaretypes/standard-medium.json
+++ b/config/defaults/hardwaretypes/standard-medium.json
@@ -5,54 +5,36 @@
     "aws-us-east-1": {
       "flavor": "m1.medium",
       "cost": "0.087",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "3.75",
-        "disks": {
-          "/dev/xvdb": "410"
-        }
-      }
+      "vcpu": "1",
+      "ram": "3.75",
+      "disk_/dev/xvdb": "410"
     },
     "aws-us-west-1": {
       "flavor": "m1.medium",
       "cost": "0.087",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "3.75",
-        "disks": {
-          "/dev/xvdb": "410"
-        }
-      }
+      "vcpu": "1",
+      "ram": "3.75",
+      "disk_/dev/xvdb": "410"
     },
     "aws-us-west-2": {
       "flavor": "m1.medium",
       "cost": "0.087",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "3.75",
-        "disks": {
-          "/dev/xvdb": "410"
-        }
-      }
+      "vcpu": "1",
+      "ram": "3.75",
+      "disk_/dev/xvdb": "410"
     },
     "joyent": {
       "flavor": "g3-standard-3.75-kvm",
       "cost": "0.12",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "3.75",
-        "disks": {
-          "/dev/vdb": "123"
-        }
-      }
+      "vcpu": "1",
+      "ram": "3.75",
+      "disk_/dev/vdb": "123"
     },
     "rackspace": {
       "flavor": "5",
       "cost": "0.36",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "4"
-      }
+      "vcpu": "2",
+      "ram": "4"
     }
   }
 }

--- a/config/defaults/hardwaretypes/standard-small.json
+++ b/config/defaults/hardwaretypes/standard-small.json
@@ -5,54 +5,36 @@
     "aws-us-east-1": {
       "flavor": "m1.small",
       "cost": "0.044",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "1.7",
-        "disks": {
-          "/dev/xvda3": "160"
-        }
-      }
+      "vcpu": "1",
+      "ram": "1.7",
+      "disk_/dev/xvda3": "160"
     },
     "aws-us-west-1": {
       "flavor": "m1.small",
       "cost": "0.044",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "1.7",
-        "disks": {
-          "/dev/xvda3": "160"
-        }
-      }
+      "vcpu": "1",
+      "ram": "1.7",
+      "disk_/dev/xvda3": "160"
     },
     "aws-us-west-2": {
       "flavor": "m1.small",
       "cost": "0.044",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "1.7",
-        "disks": {
-          "/dev/xvda3": "160"
-        }
-      }
+      "vcpu": "1",
+      "ram": "1.7",
+      "disk_/dev/xvda3": "160"
     },
     "joyent": {
       "flavor": "g3-standard-1.75-kvm",
       "cost": "0.056",
-      "hardware": {
-        "vcpu": "1",
-        "ram": "1.75",
-        "disks": {
-          "/dev/vdb": "56"
-        }
-      }
+      "vcpu": "1",
+      "ram": "1.75",
+      "disk_/dev/vdb": "56"
     },
     "rackspace": {
       "flavor": "4",
       "cost": "0.24",
-      "hardware": {
-        "vcpu": "2",
-        "ram": "2"
-      }
+      "vcpu": "2",
+      "ram": "2"
     }
   }
 }

--- a/config/defaults/hardwaretypes/standard-small.json
+++ b/config/defaults/hardwaretypes/standard-small.json
@@ -7,28 +7,28 @@
       "cost": "0.044",
       "vcpu": "1",
       "ram": "1.7",
-      "disk_/dev/xvda3": "160"
+      "disks": "/dev/xvda3=160"
     },
     "aws-us-west-1": {
       "flavor": "m1.small",
       "cost": "0.044",
       "vcpu": "1",
       "ram": "1.7",
-      "disk_/dev/xvda3": "160"
+      "disks": "/dev/xvda3=160"
     },
     "aws-us-west-2": {
       "flavor": "m1.small",
       "cost": "0.044",
       "vcpu": "1",
       "ram": "1.7",
-      "disk_/dev/xvda3": "160"
+      "disks": "/dev/xvda3=160"
     },
     "joyent": {
       "flavor": "g3-standard-1.75-kvm",
       "cost": "0.056",
       "vcpu": "1",
       "ram": "1.75",
-      "disk_/dev/vdb": "56"
+      "disks": "/dev/vdb=56"
     },
     "rackspace": {
       "flavor": "4",

--- a/config/defaults/hardwaretypes/standard-xlarge.json
+++ b/config/defaults/hardwaretypes/standard-xlarge.json
@@ -7,37 +7,28 @@
       "cost": "0.350",
       "vcpu": "4",
       "ram": "15",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420",
-      "disk_/dev/xvdd": "420",
-      "disk_/dev/xvde": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420,/dev/xvdd=420,/dev/xvde=420"
     },
     "aws-us-west-1": {
       "flavor": "m1.xlarge",
       "cost": "0.350",
       "vcpu": "4",
       "ram": "15",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420",
-      "disk_/dev/xvdd": "420",
-      "disk_/dev/xvde": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420",/dev/xvdd=420,/dev/xvde=420"
     },
     "aws-us-west-2": {
       "flavor": "m1.xlarge",
       "cost": "0.350",
       "vcpu": "4",
       "ram": "15",
-      "disk_/dev/xvdb": "420",
-      "disk_/dev/xvdc": "420",
-      "disk_/dev/xvdd": "420",
-      "disk_/dev/xvde": "420"
+      "disks": "/dev/xvdb=420,/dev/xvdc=420,/dev/xvdd=420,/dev/xvde=420"
     },
     "joyent": {
       "flavor": "g3-standard-15-kvm",
       "cost": "0.48",
       "vcpu": "4",
       "ram": "15",
-      "disk_/dev/vdb": "1467"
+      "disks": "/dev/vdb=1467"
     },
     "rackspace": {
       "flavor": "7",

--- a/config/defaults/hardwaretypes/standard-xlarge.json
+++ b/config/defaults/hardwaretypes/standard-xlarge.json
@@ -5,63 +5,45 @@
     "aws-us-east-1": {
       "flavor": "m1.xlarge",
       "cost": "0.350",
-      "hardware": {
-        "vcpu": "4",
-        "ram": "15",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420",
-          "/dev/xvdd": "420",
-          "/dev/xvde": "420"
-        }
-      }
+      "vcpu": "4",
+      "ram": "15",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420",
+      "disk_/dev/xvdd": "420",
+      "disk_/dev/xvde": "420"
     },
     "aws-us-west-1": {
       "flavor": "m1.xlarge",
       "cost": "0.350",
-      "hardware": {
-        "vcpu": "4",
-        "ram": "15",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420",
-          "/dev/xvdd": "420",
-          "/dev/xvde": "420"
-        }
-      }
+      "vcpu": "4",
+      "ram": "15",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420",
+      "disk_/dev/xvdd": "420",
+      "disk_/dev/xvde": "420"
     },
     "aws-us-west-2": {
       "flavor": "m1.xlarge",
       "cost": "0.350",
-      "hardware": {
-        "vcpu": "4",
-        "ram": "15",
-        "disks": {
-          "/dev/xvdb": "420",
-          "/dev/xvdc": "420",
-          "/dev/xvdd": "420",
-          "/dev/xvde": "420"
-        }
-      }
+      "vcpu": "4",
+      "ram": "15",
+      "disk_/dev/xvdb": "420",
+      "disk_/dev/xvdc": "420",
+      "disk_/dev/xvdd": "420",
+      "disk_/dev/xvde": "420"
     },
     "joyent": {
       "flavor": "g3-standard-15-kvm",
       "cost": "0.48",
-      "hardware": {
-        "vcpu": "4",
-        "ram": "15",
-        "disks": {
-          "/dev/vdb": "1467"
-        }
-      }
+      "vcpu": "4",
+      "ram": "15",
+      "disk_/dev/vdb": "1467"
     },
     "rackspace": {
       "flavor": "7",
       "cost": "1.02",
-      "hardware": {
-        "vcpu": "6",
-        "ram": "15"
-      }
+      "vcpu": "6",
+      "ram": "15"
     }
   }
 }

--- a/config/defaults/hardwaretypes/standard-xxlarge.json
+++ b/config/defaults/hardwaretypes/standard-xxlarge.json
@@ -7,7 +7,7 @@
       "cost": "0.96",
       "vcpu": "8",
       "ram": "30",
-      "disk_/dev/vdb": "1683"
+      "disks": "/dev/vdb=1683"
     },
     "rackspace": {
       "flavor": "8",

--- a/config/defaults/hardwaretypes/standard-xxlarge.json
+++ b/config/defaults/hardwaretypes/standard-xxlarge.json
@@ -5,21 +5,15 @@
     "joyent": {
       "flavor": "g3-standard-30-kvm",
       "cost": "0.96",
-      "hardware": {
-        "vcpu": "8",
-        "ram": "30",
-        "disks": {
-          "/dev/vdb": "1683"
-        }
-      }
+      "vcpu": "8",
+      "ram": "30",
+      "disk_/dev/vdb": "1683"
     },
     "rackspace": {
       "flavor": "8",
       "cost": "1.14",
-      "hardware": {
-        "vcpu": "8",
-        "ram": "30"
-      }
+      "vcpu": "8",
+      "ram": "30"
     }
   }
 }


### PR DESCRIPTION
a flat map of string to string, so flattening the hardware type
informational fields.
