### PR TITLE
changing the retry logic so that rollback tasks must be done

### DIFF
--- a/server/src/main/java/com/continuuity/loom/scheduler/JobScheduler.java
+++ b/server/src/main/java/com/continuuity/loom/scheduler/JobScheduler.java
@@ -156,7 +156,7 @@ public class JobScheduler implements Runnable {
             // Handle retry tasks if any
             if (!retryTasks.isEmpty()) {
               for (ClusterTask task : retryTasks) {
-                notSubmittedTasks.add(scheduleRetry(job, task, queueName));
+                notSubmittedTasks.add(scheduleRetry(job, task));
               }
             }
 
@@ -242,9 +242,7 @@ public class JobScheduler implements Runnable {
     }
   }
 
-  ClusterTask scheduleRetry(ClusterJob job, ClusterTask task, String queueName) throws Exception {
-    // Schedule rollback task before retrying
-    scheduleRollbackTask(task, queueName);
+  ClusterTask scheduleRetry(ClusterJob job, ClusterTask task) throws Exception {
 
     task.addAttempt();
     List<ClusterTask> retryTasks = taskService.getRetryTask(task);
@@ -269,25 +267,6 @@ public class JobScheduler implements Runnable {
     LOG.trace("Retry job {} for task {}", job, task);
 
     return retryTasks.get(0);
-  }
-
-  void scheduleRollbackTask(ClusterTask task, String queueName) throws Exception {
-    ClusterTask rollbackTask = taskService.getRollbackTask(task);
-
-    if (rollbackTask == null) {
-      LOG.debug("No rollback task for {}", task.getTaskId());
-      return;
-    }
-
-    clusterStore.writeClusterTask(rollbackTask);
-
-    SchedulableTask schedulableTask = new SchedulableTask(rollbackTask, null);
-    LOG.debug("Submitting rollback task {} for task {}", rollbackTask.getTaskId(), task.getTaskId());
-    LOG.trace("Task = {}. Rollback task = {}", task, rollbackTask);
-
-    // No need to retry roll back tasks.
-    provisionerQueues.add(
-      queueName, new Element(rollbackTask.getTaskId(), gson.toJson(schedulableTask)));
   }
 
   private static final Function<ClusterTask, String> CLUSTER_TASK_STRING_FUNCTION =


### PR DESCRIPTION
before the retries begin instead of letting them happen at the
same time. To make this concrete, if a node confirm task fails,
the node delete task must happen before another node create task
can begin.

This was done so that the number of nodes provisioned for a
cluster never goes over the cluster size. Before, when the node
delete happened concurrently with the node create retry, you could
actually go over the cluster size if the node create happened
before the node delete. Enforcing ordering also has the benefit
of ensuring that hostnames are always unique since the node is
guaranteed to be deleted before another one with the same config
is created.

Fixes #419 
