### PR TITLE
adding process_name label to logger

### DIFF
--- a/provisioner/master/lib/provisioner/logging.rb
+++ b/provisioner/master/lib/provisioner/logging.rb
@@ -25,6 +25,7 @@ module Loom
     @level = ::Logger::INFO
     @shift_age = nil
     @shift_size = nil
+    @process_name = '-'
     @out = nil
     def log
       Loom::Logging.log
@@ -61,6 +62,10 @@ module Loom
       @shift_size = shift_size
     end
 
+    def self.process_name=(process_name)
+      @process_name = process_name
+    end
+
     def self.log
       unless @logger
         if @out
@@ -70,7 +75,7 @@ module Loom
         end
         @logger.level = @level
         @logger.formatter = proc do |severity, datetime, progname, msg|
-          "#{datetime} #{severity}: #{msg}\n"
+          "#{datetime} #{@process_name} #{severity}: #{msg}\n"
         end
       end
       @logger

--- a/provisioner/master/lib/provisioner/provisioner.rb
+++ b/provisioner/master/lib/provisioner/provisioner.rb
@@ -45,7 +45,7 @@ module Loom
       @terminating_tenants = []
       @server_uri = config.get('provisioner.server.uri')
       pid = Process.pid
-      host = Socket.gethostname.downcase
+      host = Socket.gethostname.downcase.split('.').first
       @provisioner_id = "master-#{host}-#{pid}"
       log.info "provisioner #{@provisioner_id} initialized"
       @registered = false

--- a/provisioner/master/lib/provisioner/provisioner.rb
+++ b/provisioner/master/lib/provisioner/provisioner.rb
@@ -46,9 +46,10 @@ module Loom
       @server_uri = config.get('provisioner.server.uri')
       pid = Process.pid
       host = Socket.gethostname.downcase
-      @provisioner_id = "#{host}.#{pid}"
+      @provisioner_id = "master-#{host}-#{pid}"
       log.info "provisioner #{@provisioner_id} initialized"
       @registered = false
+      Logging.process_name = @provisioner_id
     end
 
     # invoked from bin/provisioner

--- a/provisioner/worker/provisioner.rb
+++ b/provisioner/worker/provisioner.rb
@@ -92,6 +92,7 @@ elsif options[:log_directory]
 end
 Logging.configure(log_file)
 Logging.level = options[:log_level]
+Logging.process_name = options[:name] if options[:name]
 
 # load plugins
 pluginmanager = PluginManager.new

--- a/provisioner/worker/utils.rb
+++ b/provisioner/worker/utils.rb
@@ -122,6 +122,8 @@ end
 module Logging
   attr_accessor :level
   @out = nil
+  @process_name = '-'
+
   def log
     Logging.log
   end
@@ -147,6 +149,10 @@ module Logging
     end
   end
 
+  def self.process_name=(process_name)
+    @process_name = process_name
+  end
+
   def self.log
     unless @logger
       if @out
@@ -156,7 +162,7 @@ module Logging
       end
       @logger.level = @level
       @logger.formatter = proc do |severity, datetime, progname, msg|
-        "#{datetime} #{severity}: #{msg}\n"
+        "#{datetime} #{@process_name} #{severity}: #{msg}\n"
       end
     end
     @logger


### PR DESCRIPTION
- [x] added an identifier field to the loggers, which is logged with every line.  this makes it easier to identify/search log lines when we redirect stdout to a file
- [x] master process sets this field to the provisioner id, which is modified slightly to "master-[hostname]-pid"
- [x] workers set this field to the worker name, which master sets to "worker-[tenant]-[number]"
- [ ] fyi, worker code and master code is still separate, each with their own logger... i want to combine these at some point soon.

sample logs:

```
2014-08-28 15:06:42 -0700 master-dereks-macbook-air.local-56484 INFO: starting heartbeat thread
2014-08-28 15:06:42 -0700 master-dereks-macbook-air.local-56484 INFO: Registering with server at http://localhost:55054/v2/provisioners/dereks-macbook-air.local-56484: {"id":"dereks-macbook-air.local.56484","capacityTotal":"10","host":"127.0.0.1","port":"55056"}
2014-08-28 15:06:42 -0700 master-dereks-macbook-air.local-56484 INFO: started signal processing thread
2014-08-28 15:06:42 -0700 master-dereks-macbook-air.local-56484 INFO: starting resource thread
2014-08-28 15:06:42 -0700 master-dereks-macbook-air.local-56484 INFO: Successfully registered
2014-08-28 15:06:43 -0700 master-dereks-macbook-air.local-56484 INFO: adding/updating tenant id: superadmin
2014-08-28 15:06:46 -0700 worker-superadmin-3 INFO: Starting provisioner with id dereks-macbook-air.local.56504, connecting to server http://localhost:55054
2014-08-28 15:06:46 -0700 worker-superadmin-1 INFO: Starting provisioner with id dereks-macbook-air.local.56502, connecting to server http://localhost:55054
2014-08-28 15:06:46 -0700 worker-superadmin-2 INFO: Starting provisioner with id dereks-macbook-air.local.56503, connecting to server http://localhost:55054
2014-08-28 15:06:46 -0700 worker-superadmin-5 INFO: Starting provisioner with id dereks-macbook-air.local.56506, connecting to server http://localhost:55054
2014-08-28 15:06:46 -0700 worker-superadmin-4 INFO: Starting provisioner with id dereks-macbook-air.local.56505, connecting to server http://localhost:55054
```
