### PR TITLE
Add .gitignore for scripts/validation.pem

### DIFF
--- a/provisioner/worker/plugins/automators/shell_automator/.gitignore
+++ b/provisioner/worker/plugins/automators/shell_automator/.gitignore
@@ -1,0 +1,1 @@
+scripts/validation.pem


### PR DESCRIPTION
This allows us to store our validation.pem in the scripts directory for chef_client_bootstrap.sh without committing it to the repository.
