### PR TITLE
Import hadoop version 1.3.2

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/metadata.json
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/metadata.json
@@ -42,5 +42,5 @@
   },
   "recipes": {
   },
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@continuuity.com'
 license          'Apache 2.0'
 description      'Installs/Configures Hadoop (HDFS/YARN/MRv2), HBase, Hive, Oozie, Pig, and ZooKeeper'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.1'
+version          '1.3.2'
 
 depends 'yum', '>= 3.0'
 depends 'apt'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/recipes/zookeeper.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/hadoop/recipes/zookeeper.rb
@@ -25,6 +25,7 @@ group 'zookeeper' do
   action :create
 end
 user 'zookeeper' do
+  gid 'zookeeper'
   action :create
 end
 


### PR DESCRIPTION
This fixes a bug in the `zookeeper` recipe which affects certain Hadoop distributions.
