### PR TITLE
add excludes to avoid unpredictability on file copy source

### DIFF
--- a/standalone/assembly/standalone.xml
+++ b/standalone/assembly/standalone.xml
@@ -9,6 +9,9 @@
         <fileSet>
             <directory>${project.basedir}/../provisioner</directory>
             <outputDirectory>/provisioner</outputDirectory>
+                <excludes>
+                    <exclude>**/provisioner-site.xml</exclude>
+                </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../ui</directory>


### PR DESCRIPTION
avoid telling maven to copy two different files to the same location.
