### PR TITLE
reorder gem statement

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
@@ -22,8 +22,8 @@ require_relative 'fog_provider/joyent'
 require_relative 'fog_provider/openstack'
 require_relative 'fog_provider/rackspace'
 
+gem 'fog', '~> 1.21.0'
+
 require 'fog'
 require 'ipaddr'
 require 'net/ssh'
-
-gem 'fog', '~> 1.21.0'


### PR DESCRIPTION
- [x] gem statement needs to be before the require.  otherwise it fails if newer version of fog is also installed
