### PR TITLE
prevent leaking disks by persisting on first delete attempt

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -210,7 +210,7 @@ class FogProviderGoogle < Provider
       log.debug 'Invoking server delete'
 
       # check for any disks persisted from a previous delete attempt
-      known_disks = @task['config']['disks_to_delete']
+      known_disks = @task['config']['disks']
 
       # fetch server object
       server = connection.servers.get(providerid)
@@ -218,7 +218,7 @@ class FogProviderGoogle < Provider
       if known_disks.nil? && !server.nil?
         # this is the first delete attempt, persist the names of the currently attached disks
         known_disks = server.disks.map { |d| d['source'].split('/').last }
-        @result['result']['disks_to_delete'] = known_disks
+        @result['result']['disks'] = known_disks
       end
 
       # delete server, if it exists


### PR DESCRIPTION
new delete logic to prevent "leaking" of failed disk deletes on google compute.  
- On first delete attempt, write the currently attached disk names to the task payload (if they don't already exist).
- Then for server and disks, do lookup/delete
- confirms each by expecting wait_for to either detect state change or raise notfound exception.
