### PR TITLE
launch plugin registration worker via worker_launcher

### DIFF
--- a/provisioner/master/lib/provisioner/provisioner.rb
+++ b/provisioner/master/lib/provisioner/provisioner.rb
@@ -30,6 +30,7 @@ require_relative 'cli'
 require_relative 'logging'
 require_relative 'config'
 require_relative 'constants'
+require_relative 'worker_launcher'
 
 module Loom
   # top-level class for provisioner
@@ -254,10 +255,14 @@ module Loom
       end
     end
 
-    # this is temporary until provisioner process manages worker data
     def register_plugins
-      # launch a single worker with register flag
-      exec("#{File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])} #{File.dirname(__FILE__)}/../../../worker/provisioner.rb --work-dir #{@config.get(PROVISIONER_WORK_DIR)} --uri #{@server_uri} --register")
+      worker_launcher = WorkerLauncher.new(@config)
+      worker_launcher.provisioner = @provisioner_id
+      worker_launcher.name = "plugin-registration-worker"
+      worker_launcher.register = true
+      worker_cmd = worker_launcher.cmd
+      log.debug "launching worker to register plugins: #{worker_cmd}"
+      exec(worker_cmd)
     end
 
     def unregister_from_server

--- a/provisioner/master/lib/provisioner/workerlauncher.rb
+++ b/provisioner/master/lib/provisioner/workerlauncher.rb
@@ -20,7 +20,7 @@
 # simple class to construct the ruby command used to launch a worker process
 module Loom
   class WorkerLauncher
-    attr_accessor :tenant, :provisioner, :name, :config
+    attr_accessor :tenant, :provisioner, :name, :config, :register
 
     def initialize(config)
       @config = config || {}
@@ -40,6 +40,7 @@ module Loom
       cmd += " --provisioner #{@provisioner}" unless @provisioner.nil?
       cmd += " --tenant #{@tenant}" unless @tenant.nil?
       cmd += " --name #{@name}" unless @name.nil?
+      cmd += " --register" if @register
       cmd
     end
 


### PR DESCRIPTION
- [x] fix to make `--register` launch a worker in the same way that a regular worker is spun up.  This honors any configuration settings, in particular logging settings (which were ignored previously)
