### PR TITLE
Feature/provider resources

### DIFF
--- a/config/defaults/providers/google.json
+++ b/config/defaults/providers/google.json
@@ -6,7 +6,9 @@
     "google_project": "",
     "google_client_email": "",
     "google_key_location": "/opt/loom/provisioner/worker/plugins/providers/fog_provider/google-project-id.p12",
+    "google_p12_key_name": "",
     "google_ssh_keyfile": "/opt/loom/provisioner/worker/plugins/providers/fog_provider/id_rsa",
+    "google_ssh_key_name": "",
     "google_ssh_username": "",
     "google_data_disk_size_gb": "",
     "zone_name": "us-central1-a"

--- a/config/defaults/providers/google.json
+++ b/config/defaults/providers/google.json
@@ -5,9 +5,7 @@
   "provisioner": {
     "google_project": "",
     "google_client_email": "",
-    "google_key_location": "/opt/loom/provisioner/worker/plugins/providers/fog_provider/google-project-id.p12",
     "google_p12_key_name": "",
-    "google_ssh_keyfile": "/opt/loom/provisioner/worker/plugins/providers/fog_provider/id_rsa",
     "google_ssh_key_name": "",
     "google_ssh_username": "",
     "google_data_disk_size_gb": "",

--- a/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -191,9 +191,9 @@
           [
             "google_project",
             "google_client_email",
-            "google_key_location",
-            "zone_name",
-            "google_ssh_keyfile"
+            "google_p12_key_name",
+            "google_ssh_key_name",
+            "zone_name"
           ]
         ]
       },

--- a/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -129,7 +129,7 @@
             "format": "file",
             "permissions": "0400"
         },
-        "ssh_private_keys": {
+        "ssh_keys": {
             "format": "file",
             "permissions": "0400"
         }
@@ -150,24 +150,24 @@
           "google_p12_key_name": {
             "label": "P12 key name",
             "type": "text",
-            "tip": "Name of the P12 key that has been uploaded"
+            "tip": "Name of the P12 key resource uploaded to the server"
           },
           "google_ssh_key_name": {
             "label": "ssh private key name",
             "type": "text",
-            "tip": "Name of the SSH key that has been uploaded"
+            "tip": "Name of the SSH key resource uploaded to the server"
           },
           "google_ssh_username": {
             "label": "ssh username",
             "type": "text",
-            "tip": "SSH username to use. Must match private key file, and have sudo permissions"
+            "tip": "SSH username to use. Must correspond to the google_ssh_key_name provided, and have sudo permissions"
           },
           "google_data_disk_size_gb": {
             "label": "Data disk size in GB",
             "type": "text",
             "default": 10,
             "override": true,
-            "tip": "Size of the persistent disk to be created and mounted to /data"
+            "tip": "Size of the persistent data disk to be created and mounted"
           },
           "zone_name": {
             "label": "Zone",

--- a/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -147,20 +147,10 @@
             "type": "text",
             "tip": "Service account email address, should be of the form 123456789@developer.gserviceaccount.com"
           },
-          "google_key_location": {
-            "label": "P12 key location",
-            "type": "text",
-            "tip": "Path to your P12 key, as downloaded from Google encrypted with their default passphrase (notasecret)"
-          },
           "google_p12_key_name": {
             "label": "P12 key name",
             "type": "text",
             "tip": "Name of the P12 key that has been uploaded"
-          },
-          "google_ssh_keyfile": {
-            "label": "ssh private key file",
-            "type": "text",
-            "tip": "Full path and file name to your Google SSH private key"
           },
           "google_ssh_key_name": {
             "label": "ssh private key name",

--- a/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -124,6 +124,16 @@
   "google": {
     "name": "google",
     "classname": "FogProviderGoogle",
+    "resourceTypes": {
+        "p12_keys": {
+            "format": "file",
+            "permissions": "0400"
+        },
+        "ssh_private_keys": {
+            "format": "file",
+            "permissions": "0400"
+        }
+    },
     "parameters": {
       "admin": {
         "fields": {
@@ -142,10 +152,20 @@
             "type": "text",
             "tip": "Path to your P12 key, as downloaded from Google encrypted with their default passphrase (notasecret)"
           },
+          "google_p12_key_name": {
+            "label": "P12 key name",
+            "type": "text",
+            "tip": "Name of the P12 key that has been uploaded"
+          },
           "google_ssh_keyfile": {
             "label": "ssh private key file",
             "type": "text",
             "tip": "Full path and file name to your Google SSH private key"
+          },
+          "google_ssh_key_name": {
+            "label": "ssh private key name",
+            "type": "text",
+            "tip": "Name of the SSH key that has been uploaded"
           },
           "google_ssh_username": {
             "label": "ssh username",

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -25,7 +25,7 @@ class FogProviderGoogle < Provider
 
   # plugin defined resources
   @@p12_key_dir = 'p12_keys'
-  @@ssh_key_dir = 'ssh_private_keys'
+  @@ssh_key_dir = 'ssh_keys'
 
   def create(inputmap)
     @flavor = inputmap['flavor']
@@ -44,7 +44,6 @@ class FogProviderGoogle < Provider
       validate!
       # Create the server
       log.debug "Creating #{@providerid} on Google using flavor: #{flavor}, image: #{image}"
-      log.debug "working dir: #{Dir.pwd}"
 
       # disks are managed separately, so CREATE must first create and confirm the disk to be used
       # handle boot disk
@@ -85,7 +84,6 @@ class FogProviderGoogle < Provider
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)
-      log.error(e.backtrace.join("\n"))
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -315,13 +313,13 @@ class FogProviderGoogle < Provider
       errors << 'Invalid service account email address. It must be in the gserviceaccount.com domain'
     end
     if (@google_ssh_key_name.nil? || @google_p12_key_name.nil?)
-       errors << "fields 'P12 key name' and 'ssh private key name' must be defined'"
+       errors << "Fields 'P12 key name' and 'ssh private key name' must be defined'"
     else
       ssh_key = File.join(@@ssh_key_dir, @google_ssh_key_name)
       p12_key = File.join(@@p12_key_dir, @google_p12_key_name)
       [ssh_key, p12_key].each do |key|
         next if File.readable?(key)
-        errors << "cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
+        errors << "Cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
       end
     end
     fail 'Credential validation failed!' if errors.each { |e| log.error(e) }.any?

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -23,16 +23,10 @@ require 'resolv'
 class FogProviderGoogle < Provider
   include FogProvider
 
-  def initialize(env, task)
-    super(env, task)
-    work_dir = @env[:work_dir]
-    tenant = @env[:tenant]
-    #work/superadmin/providertypes/google/p12_keys/8fa6e326c48d
-    #rovisioner/work/superadmin/providertypes/google/ssh_private_keys/derek
-    @p12_key_dir = File.join(work_dir, tenant, 'providertypes/google/p12_keys')
-    @ssh_key_dir = File.join(work_dir, tenant, 'providertypes/google/ssh_private_keys')
+  def set_environment
+    @p12_key_dir = File.join(@env[:work_dir], @env[:tenant], 'providertypes/google/p12_keys')
+    @ssh_key_dir = File.join(@env[:work_dir], @env[:tenant], 'providertypes/google/ssh_private_keys')
   end
-
 
   def create(inputmap)
     @flavor = inputmap['flavor']

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -312,15 +312,11 @@ class FogProviderGoogle < Provider
     unless @google_client_email =~ /.*gserviceaccount.com$/
       errors << 'Invalid service account email address. It must be in the gserviceaccount.com domain'
     end
-    if @google_ssh_key_name.nil? || @google_p12_key_name.nil?
-      errors << "Fields 'P12 key name' and 'ssh private key name' must be defined'"
-    else
-      ssh_key = File.join(@@ssh_key_dir, @google_ssh_key_name)
-      p12_key = File.join(@@p12_key_dir, @google_p12_key_name)
-      [ssh_key, p12_key].each do |key|
-        next if File.readable?(key)
-        errors << "Cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
-      end
+    ssh_key = File.join(@@ssh_key_dir, @google_ssh_key_name)
+    p12_key = File.join(@@p12_key_dir, @google_p12_key_name)
+    [ssh_key, p12_key].each do |key|
+      next if File.readable?(key)
+      errors << "Cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
     end
     fail 'Credential validation failed!' if errors.each { |e| log.error(e) }.any?
   end

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -265,7 +265,7 @@ class FogProviderGoogle < Provider
   def connection
     # Create connection
     # rubocop:disable UselessAssignment
-    p12_key = File.join( @@p12_key_dir, @google_p12_key_name)
+    p12_key = File.join(@@p12_key_dir, @google_p12_key_name)
     @connection ||= begin
       connection = Fog::Compute.new(
         provider: 'google',
@@ -312,8 +312,8 @@ class FogProviderGoogle < Provider
     unless @google_client_email =~ /.*gserviceaccount.com$/
       errors << 'Invalid service account email address. It must be in the gserviceaccount.com domain'
     end
-    if (@google_ssh_key_name.nil? || @google_p12_key_name.nil?)
-       errors << "Fields 'P12 key name' and 'ssh private key name' must be defined'"
+    if @google_ssh_key_name.nil? || @google_p12_key_name.nil?
+      errors << "Fields 'P12 key name' and 'ssh private key name' must be defined'"
     else
       ssh_key = File.join(@@ssh_key_dir, @google_ssh_key_name)
       p12_key = File.join(@@p12_key_dir, @google_p12_key_name)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -23,10 +23,9 @@ require 'resolv'
 class FogProviderGoogle < Provider
   include FogProvider
 
-  def set_environment
-    @p12_key_dir = File.join(@env[:work_dir], @env[:tenant], 'providertypes/google/p12_keys')
-    @ssh_key_dir = File.join(@env[:work_dir], @env[:tenant], 'providertypes/google/ssh_private_keys')
-  end
+  # plugin defined resources
+  @@p12_key_dir = 'p12_keys'
+  @@ssh_key_dir = 'ssh_private_keys'
 
   def create(inputmap)
     @flavor = inputmap['flavor']
@@ -45,6 +44,7 @@ class FogProviderGoogle < Provider
       validate!
       # Create the server
       log.debug "Creating #{@providerid} on Google using flavor: #{flavor}, image: #{image}"
+      log.debug "working dir: #{Dir.pwd}"
 
       # disks are managed separately, so CREATE must first create and confirm the disk to be used
       # handle boot disk
@@ -81,10 +81,11 @@ class FogProviderGoogle < Provider
           'root'
         end
       @result['result']['ssh-auth']['user'] = ssh_user
-      @result['result']['ssh-auth']['identityfile'] = File.join(@ssh_key_dir, @google_ssh_key_name)
+      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @google_ssh_key_name)
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)
+      log.error(e.backtrace.join("\n"))
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -266,7 +267,7 @@ class FogProviderGoogle < Provider
   def connection
     # Create connection
     # rubocop:disable UselessAssignment
-    p12_key = File.join( @p12_key_dir, @google_p12_key_name)
+    p12_key = File.join( @@p12_key_dir, @google_p12_key_name)
     @connection ||= begin
       connection = Fog::Compute.new(
         provider: 'google',
@@ -313,11 +314,15 @@ class FogProviderGoogle < Provider
     unless @google_client_email =~ /.*gserviceaccount.com$/
       errors << 'Invalid service account email address. It must be in the gserviceaccount.com domain'
     end
-    ssh_key = File.join(@ssh_key_dir, @google_ssh_key_name)
-    p12_key = File.join( @p12_key_dir, @google_p12_key_name)
-    [ssh_key, p12_key].each do |key|
-      next if File.readable?(key)
-      errors << "cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
+    if (@google_ssh_key_name.nil? || @google_p12_key_name.nil?)
+       errors << "fields 'P12 key name' and 'ssh private key name' must be defined'"
+    else
+      ssh_key = File.join(@@ssh_key_dir, @google_ssh_key_name)
+      p12_key = File.join(@@p12_key_dir, @google_p12_key_name)
+      [ssh_key, p12_key].each do |key|
+        next if File.readable?(key)
+        errors << "cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"
+      end
     end
     fail 'Credential validation failed!' if errors.each { |e| log.error(e) }.any?
   end

--- a/provisioner/worker/provisioner.rb
+++ b/provisioner/worker/provisioner.rb
@@ -127,10 +127,12 @@ def delegate_task(task, pluginmanager)
   when 'create', 'confirm', 'delete'
     clazz = Object.const_get(pluginmanager.getHandlerActionObjectForProvider(providerName))
     object = clazz.new(@plugin_env, task)
+    object.set_environment if object.respond_to? :set_environment
     result = object.runTask
   when 'install', 'configure', 'initialize', 'start', 'stop', 'remove'
     clazz = Object.const_get(pluginmanager.getHandlerActionObjectForAutomator(automatorName))
     object = clazz.new(@plugin_env, task)
+    object.set_environment if object.respond_to? :set_environment
     result = object.runTask
   when 'bootstrap'
     combinedresult = {}
@@ -151,6 +153,7 @@ def delegate_task(task, pluginmanager)
     classes.each do |klass|
       klass = Object.const_get(klass)
       object = klass.new(@plugin_env, task)
+      object.set_environment if object.respond_to? :set_environment
       result = object.runTask
       combinedresult.merge!(result)
     end

--- a/provisioner/worker/provisioner.rb
+++ b/provisioner/worker/provisioner.rb
@@ -73,25 +73,25 @@ if loom_uri.nil? && !options[:file]
   exit(1)
 end
 
-unless(options[:work_dir])
-  puts "--work-dir option must be specified"
+unless options[:work_dir]
+  puts '--work-dir option must be specified'
   exit(1)
 end
 
-unless (options[:tenant] || options[:register])
-  puts "Either --tenant or --register options must be specified"
+unless options[:tenant] || options[:register]
+  puts 'Either --tenant or --register options must be specified'
   exit(1)
 end
 
-if(loom_uri.nil? && options[:register])
-  puts "--register option requires the --uri [server uri] option"
+if loom_uri.nil? && options[:register]
+  puts '--register option requires the --uri [server uri] option'
   exit(1)
 end
 
 include Logging
 log_file = nil
 if options[:log_directory] && options[:name]
-  log_file = [ options[:log_directory], options[:name] ].join('/') + '.log'
+  log_file = [options[:log_directory], options[:name]].join('/') + '.log'
 elsif options[:log_directory]
   log_file = "#{options[:log_directory]}/worker-default.log"
 end
@@ -109,7 +109,7 @@ if pluginmanager.providermap.empty? or pluginmanager.automatormap.empty?
 end
 
 # the environment passed to plugins
-@plugin_env = options 
+@plugin_env = options
 
 def delegate_task(task, pluginmanager)
   providerName = nil # rubocop:disable UselessAssignment
@@ -159,7 +159,7 @@ def delegate_task(task, pluginmanager)
         combinedresult.merge!(result)
       end
     else
-      log.warn "No automators specified to bootstrap"
+      log.warn 'No automators specified to bootstrap'
     end
     result = combinedresult
   else
@@ -172,12 +172,12 @@ end
 # register plugins with the server if --register flag passed
 if options[:register]
   pluginmanager.register_plugins(loom_uri)
-  if (pluginmanager.load_errors?)
-    log.error "There was at least one provisioner plugin load failure"
+  if pluginmanager.load_errors?
+    log.error 'There was at least one provisioner plugin load failure'
     exit(1)
   end
-  if (pluginmanager.register_errors?)
-    log.error "There was at least one provisioner plugin register failure"
+  if pluginmanager.register_errors?
+    log.error 'There was at least one provisioner plugin register failure'
     exit(1)
   end
   exit(0)
@@ -199,7 +199,7 @@ if options[:file]
     sigterm.dont_interupt {
       result = delegate_task(task, pluginmanager)
     }
-  rescue Exception => e
+  rescue => e
     log.error "Caught exception when running task from file #{options[:file]}"
 
     result = {} if result.nil? == true
@@ -264,7 +264,7 @@ else
         result['provisionerId'] = options[:provisioner]
         result['tenantId'] = options[:tenant]
 
-        log.debug "Task <#{task["taskId"]}> completed, updating results <#{result}>"
+        log.debug "Task <#{task['taskId']}> completed, updating results <#{result}>"
         begin
           response = RestClient.post "#{loom_uri}/v2/tasks/finish", result.to_json
         rescue => e
@@ -286,7 +286,7 @@ else
           result['stdout'] = e.inspect
           result['stderr'] = "#{e.inspect}\n#{e.backtrace.join("\n")}"
         end
-        log.error "Task <#{task["taskId"]}> failed, updating results <#{result}>"
+        log.error "Task <#{task['taskId']}> failed, updating results <#{result}>"
         begin
           response = RestClient.post "#{loom_uri}/v2/tasks/finish", result.to_json
         rescue => e

--- a/provisioner/worker/provisioner.rb
+++ b/provisioner/worker/provisioner.rb
@@ -78,6 +78,11 @@ unless(options[:work_dir])
   exit(1)
 end
 
+unless (options[:tenant] || options[:register])
+  puts "Either --tenant or --register options must be specified"
+  exit(1)
+end
+
 if(loom_uri.nil? && options[:register])
   puts "--register option requires the --uri [server uri] option"
   exit(1)

--- a/provisioner/worker/provisioner.rb
+++ b/provisioner/worker/provisioner.rb
@@ -132,7 +132,6 @@ def delegate_task(task, pluginmanager)
   when 'create', 'confirm', 'delete'
     clazz = Object.const_get(pluginmanager.getHandlerActionObjectForProvider(providerName))
     object = clazz.new(@plugin_env, task)
-    object.set_environment if object.respond_to? :set_environment
     cwd = File.join(@plugin_env[:work_dir], @plugin_env[:tenant], 'providertypes', providerName)
     Dir.chdir(cwd) do
       result = object.runTask
@@ -140,7 +139,6 @@ def delegate_task(task, pluginmanager)
   when 'install', 'configure', 'initialize', 'start', 'stop', 'remove'
     clazz = Object.const_get(pluginmanager.getHandlerActionObjectForAutomator(automatorName))
     object = clazz.new(@plugin_env, task)
-    object.set_environment if object.respond_to? :set_environment
     cwd = File.join(@plugin_env[:work_dir], @plugin_env[:tenant], 'automatortypes', automatorName)
     Dir.chdir(cwd) do
       result = object.runTask
@@ -154,7 +152,6 @@ def delegate_task(task, pluginmanager)
       task['config']['automators'].each do |automator|
         clazz = Object.const_get(pluginmanager.getHandlerActionObjectForAutomator(automator))
         object = clazz.new(@plugin_env, task)
-        object.set_environment if object.respond_to? :set_environment
         cwd = File.join(@plugin_env[:work_dir], @plugin_env[:tenant], 'automatortypes', automator)
         Dir.chdir(cwd) do
           result = object.runTask


### PR DESCRIPTION
this PR improves support for uploading of plugin credentials, and passing the necessary info to the plugins.  google provider updates included in this PR, other plugins will follow in separate PRs

changes to provisioner worker:
- [x] sets the current working directory to the plugin's resource work dir, for the duration of the plugin's execution
- [x] bootstrap now relies on `task['config']['automators']`.  removed the default case of running bootstrap for all known automators, since this should never happen, and the code to handle this case was getting ugly.

changes to the google provider:
- [x] class variables to define the known relative paths for resources (matching those defined in the json)
- [x] constructing the resource path from those, and validating up front.
