### PR TITLE
Feature/standalone build

### DIFF
--- a/standalone/assembly/standalone.xml
+++ b/standalone/assembly/standalone.xml
@@ -37,6 +37,10 @@
             </includes>
         </fileSet>
         <fileSet>
+            <directory>${project.basedir}/../server/bin</directory>
+            <outputDirectory>/server/bin</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>${project.basedir}/../standalone/bin</directory>
             <outputDirectory>/bin</outputDirectory>
         </fileSet>

--- a/standalone/assembly/standalone.xml
+++ b/standalone/assembly/standalone.xml
@@ -29,14 +29,6 @@
             <outputDirectory>/licenses</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/../bin</directory>
-            <outputDirectory>/bin</outputDirectory>
-            <includes>
-                <include>loom-*.sh</include>
-                <include>data-uploader*</include>
-            </includes>
-        </fileSet>
-        <fileSet>
             <directory>${project.basedir}/../server/bin</directory>
             <outputDirectory>/server/bin</outputDirectory>
         </fileSet>

--- a/standalone/bin/loom.sh
+++ b/standalone/bin/loom.sh
@@ -258,9 +258,9 @@ function provisioner () {
     fi
     if [ "x${LOOM_USE_DUMMY_PROVISIONER}" == "xtrue" ]
     then
-        $LOOM_HOME/bin/dummy-provisioner.sh $1
+        $LOOM_HOME/server/bin/dummy-provisioner.sh $1
     else
-        $LOOM_HOME/bin/provisioner.sh $1
+        $LOOM_HOME/provisioner/bin/provisioner.sh $1
     fi
 }
 
@@ -271,8 +271,8 @@ function greeting () {
 
 case "$1" in
   start)
-    $LOOM_HOME/bin/server.sh start && \
-    $LOOM_HOME/bin/ui.sh start && \
+    $LOOM_HOME/server/bin/server.sh start && \
+    $LOOM_HOME/ui/bin/ui.sh start && \
     load_defaults && \
     provisioner start && \
     request_superadmin_workers && \
@@ -281,22 +281,22 @@ case "$1" in
 
   stop)
     provisioner stop
-    $LOOM_HOME/bin/server.sh stop
-    $LOOM_HOME/bin/ui.sh stop
+    $LOOM_HOME/server/bin/server.sh stop
+    $LOOM_HOME/ui/bin/ui.sh stop
   ;;
 
   restart)
     provisioner stop
-    $LOOM_HOME/bin/ui.sh stop
-    $LOOM_HOME/bin/server.sh stop
-    $LOOM_HOME/bin/server.sh start
-    $LOOM_HOME/bin/ui.sh start
+    $LOOM_HOME/ui/bin/ui.sh stop
+    $LOOM_HOME/server/bin/server.sh stop
+    $LOOM_HOME/server/bin/server.sh start
+    $LOOM_HOME/ui/bin/ui.sh start
     provisioner start
   ;;
 
   status)
-    $LOOM_HOME/bin/server.sh status
-    $LOOM_HOME/bin/ui.sh status
+    $LOOM_HOME/server/bin/server.sh status
+    $LOOM_HOME/server/bin/ui.sh status
     provisioner status
   ;;
 


### PR DESCRIPTION
updating standalone build after init scripts moved into their respective component directories
- [x] updated loom.sh to refer to [component]/bin/*.sh
- [x] added missing server/bin to standalone.xml and removed top-level bin pattern which no longer matched anything

final result:

```
./bin/loom.sh
./provisioner/bin/data-uploader.rb
./provisioner/bin/provisioner.sh
./server/bin/dummy-provisioner.sh
./server/bin/server.sh
./ui/bin/ui.sh
```
