### PR TITLE
Feature/use embedded ruby

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
@@ -8,7 +8,8 @@ LOOM_API_KEY=${LOOM_API_KEY:-1234567890abcdef}
 LOOM_TENANT=${LOOM_TENANT:-superadmin}
 CHEF_SOLO_DIR=${LOOM_HOME}/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator
 
-LOOM_RUBY=${LOOM_RUBY:-ruby}
+LOOM_RUBY=${LOOM_RUBY:-"${LOOM_HOME}/provisioner/embedded/bin/ruby"}
+test -x ${LOOM_RUBY} || LOOM_RUBY="ruby"
 DATA_UPLOADER="${LOOM_RUBY} ${LOOM_HOME}/provisioner/bin/data-uploader.rb"
 
 COOKBOOKS_DIR=${CHEF_SOLO_DIR}/cookbooks

--- a/provisioner/worker/plugins/automators/shell_automator/load-bundled-data.sh
+++ b/provisioner/worker/plugins/automators/shell_automator/load-bundled-data.sh
@@ -8,7 +8,8 @@ LOOM_API_KEY=${LOOM_API_KEY:-1234567890abcdef}
 LOOM_TENANT=${LOOM_TENANT:-superadmin}
 SHELL_DIR=${LOOM_HOME}/provisioner/worker/plugins/automators/shell_automator
 
-LOOM_RUBY=${LOOM_RUBY:-ruby}
+LOOM_RUBY=${LOOM_RUBY:-"${LOOM_HOME}/provisioner/embedded/bin/ruby"}
+test -x ${LOOM_RUBY} || LOOM_RUBY="ruby"
 DATA_UPLOADER="${LOOM_RUBY} ${LOOM_HOME}/provisioner/bin/data-uploader.rb"
 
 SCRIPTS_DIR=${SHELL_DIR}/scripts


### PR DESCRIPTION
Default LOOM_RUBY to the embedded/bin/ruby, but fallback to just ruby if it cannot be found
