### PR TITLE
invoking tar with -h which is consistent between gnu and bsd tar

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -43,7 +43,7 @@ class ChefSoloAutomator < Automator
     # rubocop:disable GuardClause
     if !File.exist?(chef_primitive_tar) or ((Time.now - File.stat(chef_primitive_tar).mtime).to_i > 600)
       log.debug "Generating #{chef_primitive_tar} from #{chef_primitive_path}"
-      `tar -cLzf "#{chef_primitive_tar}.new" #{chef_primitive}`
+      `tar -chzf "#{chef_primitive_tar}.new" #{chef_primitive}`
       `mv "#{chef_primitive_tar}.new" "#{chef_primitive_tar}"`
       log.debug "Generation complete: #{chef_primitive_tar}"
     end

--- a/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -52,7 +52,7 @@ class ShellAutomator < Automator
   def generate_tar(file, path)
     return if File.exist?(file) && ((Time.now - File.stat(file).mtime).to_i < 600)
     log.debug "Generating #{file} from #{path}"
-    `tar -cLzf "#{file}.new" -C "#{File.dirname(path)}" #{File.basename(path)}`
+    `tar -chzf "#{file}.new" -C "#{File.dirname(path)}" #{File.basename(path)}`
     `mv "#{file}.new" "#{file}"`
     log.debug "Generation complete: #{file}"
   end


### PR DESCRIPTION
making the tar shell out work with both gnu tar and bsd tar (mac).  Filed issue #517 to get rid of the shell out.
