### PR TITLE
Remove debug logging of credentials in connection def

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -249,11 +249,6 @@ class FogProviderAWS < Provider
   # Shared definitions (borrowed from knife-ec2 gem, Apache 2.0 license)
 
   def connection
-    log.debug 'Connection options for AWS:'
-    log.debug "- aws_access_key_id #{@aws_access_key}"
-    log.debug "- aws_secret_access_key #{@aws_secret_key}"
-    log.debug "- aws_region #{@aws_region}"
-
     # Create connection
     # rubocop:disable UselessAssignment
     @connection ||= begin

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -168,14 +168,6 @@ class FogProviderJoyent < Provider
   # Shared definitions (borrowed from knife-joyent gem, Apache 2.0 license)
 
   def connection
-    log.debug 'Connection options for Joyent:'
-    log.debug "- joyent_username #{@joyent_username}"
-    log.debug "- joyent_password #{@joyent_password}" if @joyent_password
-    log.debug "- joyent_keyname #{@joyent_keyname}"
-    log.debug "- joyent_keyfile #{@joyent_keyfile}"
-    log.debug "- joyent_api_url #{@joyent_api_url}"
-    log.debug "- joyent_version #{@joyent_version}"
-
     # Create connection
     # rubocop:disable UselessAssignment
     @connection ||= begin

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -153,13 +153,6 @@ class FogProviderOpenstack < Provider
   # Shared definitions (borrowed from knife-openstack gem, Apache 2.0 license)
 
   def connection
-    log.debug 'Connection options for Openstack:'
-    log.debug "- openstack_username #{@openstack_username}"
-    log.debug "- openstack_password #{@openstack_password}"
-    log.debug "- openstack_tenant #{@openstack_tenant}"
-    log.debug "- openstack_auth_url #{@openstack_auth_url}"
-    log.debug "- openstack_ssl_verify_peer #{@openstack_ssl_verify_peer}"
-
     # Create connection
     # rubocop:disable UselessAssignment
     @connection ||= begin

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -166,12 +166,6 @@ class FogProviderRackspace < Provider
   # Shared definitions (borrowed from knife-rackspace gem, Apache 2.0 license)
 
   def connection
-    log.debug 'Connection options for Rackspace:'
-    log.debug "- rackspace_api_key #{@rackspace_api_key}"
-    log.debug "- rackspace_username #{@rackspace_username}"
-    log.debug "- rackspace_region #{@rackspace_region}"
-    log.debug "- rackspace_auth_url #{auth_endpoint}"
-
     # Create connection
     # rubocop:disable UselessAssignment
     @connection ||= begin


### PR DESCRIPTION
We do not need to expose credentials at every connection. Removing the debugging output, since it's not necessary and can leak credentials.
