### PR TITLE
use explicit logic for deserializing a cluster operation request

### DIFF
--- a/server/src/main/java/com/continuuity/loom/codec/json/current/ClusterOperationRequestCodec.java
+++ b/server/src/main/java/com/continuuity/loom/codec/json/current/ClusterOperationRequestCodec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2014, Continuuity, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.continuuity.loom.codec.json.current;
+
+import com.continuuity.loom.http.request.ClusterOperationRequest;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Codec for deserializing a {@link com.continuuity.loom.http.request.ClusterOperationRequest}, used so some validation
+ * is done on required fields.
+ */
+public class ClusterOperationRequestCodec implements JsonDeserializer<ClusterOperationRequest> {
+
+  @Override
+  public ClusterOperationRequest deserialize(JsonElement json, Type type, JsonDeserializationContext context)
+    throws JsonParseException {
+    JsonObject jsonObj = json.getAsJsonObject();
+
+    Map<String, String> providerFields =
+      context.deserialize(jsonObj.get("providerFields"), new TypeToken<Map<String, String>>() {}.getType());
+    return new ClusterOperationRequest(providerFields);
+  }
+}

--- a/server/src/main/java/com/continuuity/loom/codec/json/guice/CodecModules.java
+++ b/server/src/main/java/com/continuuity/loom/codec/json/guice/CodecModules.java
@@ -19,6 +19,7 @@ import com.continuuity.loom.cluster.Cluster;
 import com.continuuity.loom.cluster.Node;
 import com.continuuity.loom.codec.json.LowercaseEnumTypeAdapterFactory;
 import com.continuuity.loom.codec.json.current.AddServicesRequestCodec;
+import com.continuuity.loom.codec.json.current.ClusterOperationRequestCodec;
 import com.continuuity.loom.codec.json.current.TenantWriteRequestCodec;
 import com.continuuity.loom.codec.json.current.AdministrationCodec;
 import com.continuuity.loom.codec.json.current.AutomatorTypeCodec;
@@ -59,6 +60,7 @@ import com.continuuity.loom.codec.json.upgrade.ProviderUpgradeCodec;
 import com.continuuity.loom.codec.json.upgrade.ServiceActionUpgradeCodec;
 import com.continuuity.loom.codec.json.upgrade.ServiceUpgradeCodec;
 import com.continuuity.loom.http.request.AddServicesRequest;
+import com.continuuity.loom.http.request.ClusterOperationRequest;
 import com.continuuity.loom.http.request.TenantWriteRequest;
 import com.continuuity.loom.http.request.ClusterConfigureRequest;
 import com.continuuity.loom.http.request.ClusterCreateRequest;
@@ -148,6 +150,7 @@ public class CodecModules {
       .registerTypeAdapter(ClusterConfigureRequest.class, new ClusterConfigureRequestCodec())
       .registerTypeAdapter(ClusterCreateRequest.class, new ClusterCreateRequestCodec())
       .registerTypeAdapter(ClusterDefaults.class, new ClusterDefaultsCodec())
+      .registerTypeAdapter(ClusterOperationRequest.class, new ClusterOperationRequestCodec())
       .registerTypeAdapter(ClusterTemplate.class, new ClusterTemplateCodec())
       .registerTypeAdapter(Constraints.class, new ConstraintsCodec())
       .registerTypeAdapter(FieldSchema.class, new FieldSchemaCodec())


### PR DESCRIPTION
so the constructor is actually called and null checks performed.
