### PR TITLE
Feature/full path resources

### DIFF
--- a/config/defaults/providers/aws-us-east-1.json
+++ b/config/defaults/providers/aws-us-east-1.json
@@ -5,7 +5,7 @@
   "provisioner": {
     "api_user": "",
     "api_password": "",
-    "ssh_keypair": "aws-us-east-1",
+    "ssh_keypair": "",
     "ssh_key_resource": "",
     "aws_region": "us-east-1"
   }

--- a/config/defaults/providers/aws-us-west-1.json
+++ b/config/defaults/providers/aws-us-west-1.json
@@ -5,7 +5,7 @@
   "provisioner": {
     "api_user": "",
     "api_password": "",
-    "ssh_keypair": "aws-us-west-1",
+    "ssh_keypair": "",
     "ssh_key_resource": "",
     "aws_region": "us-west-1"
   }

--- a/config/defaults/providers/aws-us-west-2.json
+++ b/config/defaults/providers/aws-us-west-2.json
@@ -5,7 +5,7 @@
   "provisioner": {
     "api_user": "",
     "api_password": "",
-    "ssh_keypair": "aws-us-west-2",
+    "ssh_keypair": "",
     "ssh_key_resource": "",
     "aws_region": "us-west-2"
   }

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -48,7 +48,7 @@ class FogProviderAWS < Provider
       # Process results
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
-      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderAWS.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -24,7 +24,10 @@ class FogProviderAWS < Provider
   include FogProvider
 
   # plugin defined resources
-  @@ssh_key_dir = 'ssh_keys'
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :ssh_key_dir
+  end
 
   def create(inputmap)
     @flavor = inputmap['flavor']
@@ -48,7 +51,7 @@ class FogProviderAWS < Provider
       # Process results
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
-      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderAWS.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -80,7 +80,7 @@ class FogProviderGoogle < Provider
           'root'
         end
       @result['result']['ssh-auth']['user'] = sshuser
-      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @ssh_key_resource)
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource)
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -24,8 +24,11 @@ class FogProviderGoogle < Provider
   include FogProvider
 
   # plugin defined resources
-  @@p12_key_dir = 'api_keys'
-  @@ssh_key_dir = 'ssh_keys'
+  @p12_key_dir = 'api_keys'
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :p12_key_dir, :ssh_key_dir
+  end
 
   def create(inputmap)
     @flavor = inputmap['flavor']
@@ -80,7 +83,7 @@ class FogProviderGoogle < Provider
           'root'
         end
       @result['result']['ssh-auth']['user'] = sshuser
-      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource)
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource)
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)
@@ -281,7 +284,7 @@ class FogProviderGoogle < Provider
   def connection
     # Create connection
     # rubocop:disable UselessAssignment
-    p12_key = File.join(@@p12_key_dir, @api_key_resource)
+    p12_key = File.join(self.class.p12_key_dir, @api_key_resource)
     @connection ||= begin
       connection = Fog::Compute.new(
         provider: 'google',
@@ -328,8 +331,8 @@ class FogProviderGoogle < Provider
     unless @google_client_email =~ /.*gserviceaccount.com$/
       errors << 'Invalid service account email address. It must be in the gserviceaccount.com domain'
     end
-    ssh_key = File.join(@@ssh_key_dir, @ssh_key_resource)
-    p12_key = File.join(@@p12_key_dir, @api_key_resource)
+    ssh_key = File.join(self.class.ssh_key_dir, @ssh_key_resource)
+    p12_key = File.join(self.class.p12_key_dir, @api_key_resource)
     [ssh_key, p12_key].each do |key|
       next if File.readable?(key)
       errors << "Cannot read named key from resource directory: #{key}. Please ensure you have uploaded a key via the UI or API"

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -22,7 +22,10 @@ class FogProviderJoyent < Provider
   include FogProvider
 
   # plugin defined resources
-  @@ssh_key_dir = 'ssh_keys'
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :ssh_key_dir
+  end
 
   def create(inputmap)
     flavor = inputmap['flavor']
@@ -48,7 +51,7 @@ class FogProviderJoyent < Provider
       # Process results
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
-      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderJoyent.create:' + e.inspect)
@@ -184,7 +187,7 @@ class FogProviderJoyent < Provider
         joyent_username: @api_user,
         joyent_password: @api_password,
         joyent_keyname: @ssh_keypair,
-        joyent_keyfile: File.join(@@ssh_key_dir, @ssh_key_resource),
+        joyent_keyfile: File.join(self.class.ssh_key_dir, @ssh_key_resource),
         joyent_url: @joyent_api_url,
         joyent_version: @joyent_version
       )

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -48,7 +48,7 @@ class FogProviderJoyent < Provider
       # Process results
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
-      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderJoyent.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -50,7 +50,7 @@ class FogProviderOpenstack < Provider
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
-      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderOpenstack.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -22,7 +22,10 @@ class FogProviderOpenstack < Provider
   include FogProvider
 
   # plugin defined resources
-  @@ssh_key_dir = 'ssh_keys'
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :ssh_key_dir
+  end
 
   def create(inputmap)
     flavor = inputmap['flavor']
@@ -50,7 +53,7 @@ class FogProviderOpenstack < Provider
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
-      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderOpenstack.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -22,7 +22,10 @@ class FogProviderRackspace < Provider
   include FogProvider
 
   # plugin defined resources
-  @@ssh_key_dir = 'ssh_keys'
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :ssh_key_dir
+  end
 
   def create(inputmap)
     flavor = inputmap['flavor']
@@ -54,7 +57,7 @@ class FogProviderRackspace < Provider
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
-      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderRackspace.create:' + e.inspect)

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -54,7 +54,7 @@ class FogProviderRackspace < Provider
       @result['result']['providerid'] = server.id.to_s
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
-      @result['result']['ssh-auth']['identityfile'] = File.join(@@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
+      @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, @@ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderRackspace.create:' + e.inspect)


### PR DESCRIPTION
- [x] when writing `ssh-auth['identityfile]` back to the payload, expand to absolute path
- [x] changing the class variables (`@@ssh_key_dir`) to "class instance variables" with accessor methods.  this is generally recommended as it is more flexible in inheritence
- [x] minor cleanup on aws default provider
