### PR TITLE
updating username to user

### DIFF
--- a/config/defaults/providers/google.json
+++ b/config/defaults/providers/google.json
@@ -7,7 +7,7 @@
     "google_client_email": "",
     "api_key_resource": "",
     "ssh_key_resource": "",
-    "ssh_username": "",
+    "ssh_user": "",
     "google_data_disk_size_gb": "",
     "zone_name": "us-central1-a"
   }


### PR DESCRIPTION
default provider used `ssh_username` instead of `ssh_user` used everywhere else
