### PR TITLE
adding google-api-client gem with same requirements as fog

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'fog', '~> 1.21.0'
 gem 'net/ssh'
+gem 'google-api-client', '~> 0.6', '>= 0.6.2'


### PR DESCRIPTION
updating the fog provider plugin gemfile with google-api-client, same versions as fog.
