### PR TITLE
Always exit 0, even if last if does not match

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/load-bundled-data.sh
@@ -45,3 +45,6 @@ for f in $(ls -1 {*.rb,*.json} 2>/dev/null) ; do
   [[ ${ret} -ne 0 ]] && failed="${failed} ${f}"
 done
 [[ ${failed} ]] && echo "Failed to load role: ${failed}" && exit 1
+
+# We reached the end! Rejoice!
+exit 0

--- a/provisioner/worker/plugins/automators/shell_automator/load-bundled-data.sh
+++ b/provisioner/worker/plugins/automators/shell_automator/load-bundled-data.sh
@@ -34,3 +34,6 @@ for d in $(ls -p -1 | grep "/$" | sed "s,/$,,") ; do
   [[ ${ret} -ne 0 ]] && failed="${failed} ${d}"
 done
 [[ ${failed} ]] && echo "Failed to load data_bag: ${failed}" && exit 1
+
+# We reached the end! Rejoice!
+exit 0


### PR DESCRIPTION
Otherwise, the final test doesn't match, and we exit with 1 (false) because we had no failures to match. Oops!
