### PR TITLE
hbase services may run into install errors if zookeeper-server

### DIFF
--- a/config/defaults/services/hbase-master.json
+++ b/config/defaults/services/hbase-master.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "conflicts": [],
     "install": {
-      "requires": [ "base" ],
+      "requires": [ "base", "zookeeper-server" ],
       "uses": [ "kerberos-client" ]
     },
     "provides": [],

--- a/config/defaults/services/hbase-regionserver.json
+++ b/config/defaults/services/hbase-regionserver.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "conflicts": [],
     "install": {
-      "requires": [ "base" ],
+      "requires": [ "base", "zookeeper-server" ],
       "uses": [ "kerberos-client" ]
     },
     "provides": [],


### PR DESCRIPTION
is not installed first. This is a workaround, as
ideally the cookbook/service would install without an ordering
requirement.
