### PR TITLE
Remove old compatibility code for Loom 0.9.7 and below

### DIFF
--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -128,100 +128,91 @@ class FogProviderAWS < Provider
       # Validate connectivity
 
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        # Backwards-compatibility... ssh_exec! takes 2 arguments prior to 0.9.8
-        ssho = method(:ssh_exec!)
-        if ssho.arity == 2
-          log.debug 'Validating external connectivity and DNS resolution via ping'
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com')
-          log.debug "Setting hostname to #{hostname}"
-          ssh_exec!(ssh, "#{sudo} hostname #{hostname}")
-        else
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
-          ssh_exec!(ssh, "#{sudo} hostname #{hostname}", "Setting hostname to #{hostname}")
-          # Setting up disks
-          log.debug 'Starting disk configuration'
-          if server.root_device_type == 'ebs'
-            log.debug 'EBS-backed instance detected...'
-            begin
-              extfs = true
-              ssh_exec!(ssh, "mount | grep xvde | awk '{print $5}' | grep -e 'ext[3-4]'", 'Checking filesystem')
-            rescue
-              extfs = false
-            end
-            if extfs
-              log.debug 'File-system is EXT3/EXT4'
-              # resize2fs is safe to execute
-              ssh_exec!(ssh, "test -x /sbin/resize2fs && #{sudo} /sbin/resize2fs /dev/xvde", 'Resizing filesystem')
-            end
-          else
-            log.debug 'Instance store detected...'
-            begin
-              # m1.small uses /dev/xvda2 for data
-              xvda = true
-              xvdb = false
-              xvdc = false
-              ssh_exec!(ssh, 'test -e /dev/xvda2', 'Checking for /dev/xvda2')
-            rescue
-              xvda = false
-              begin
-                xvdb = true
-                ssh_exec!(ssh, 'test -e /dev/xvdb', 'Checking for /dev/xvdb')
-                # Do we have /dev/xvdc, too?
-                begin
-                  xvdc = true
-                  ssh_exec!(ssh, 'test -e /dev/xvdc', 'Checking for /dev/xvdc')
-                rescue
-                  xvdc = false
-                end
-              rescue
-                xvdb = false
-              end
-            end
-
-            log.debug 'Found the following:'
-            log.debug "- xvda = #{xvda}"
-            log.debug "- xvdb = #{xvdb}"
-            log.debug "- xvdc = #{xvdc}"
-
-            # Now, do the right thing
-            if xvdc
-              # Check for APT
-              begin
-                apt = true
-                ssh_exec!(ssh, 'which apt-get', 'Checking for apt-get')
-              rescue
-                apt = false
-              end
-              # Install mdadm
-              if apt
-                ssh_exec!(ssh, "#{sudo} apt-get update", 'Running apt-get update')
-                # Setup nullmailer
-                ssh_exec!(ssh, "echo 'nullmailer shared/mailname string localhost' | #{sudo} debconf-set-selections && echo 'nullmailer nullmailer/relayhost string localhost' | #{sudo} debconf-set-selections", 'Configuring nullmailer')
-                ssh_exec!(ssh, "#{sudo} apt-get install nullmailer -y", 'Installing nullmailer')
-                ssh_exec!(ssh, "#{sudo} apt-get install mdadm -y", 'Installing mdadm')
-              else
-                ssh_exec!(ssh, "#{sudo} yum install mdadm -y", 'Installing mdadm')
-              end
-              ssh_exec!(ssh, "mount | grep ^/dev/xvdb 2>&1 >/dev/null && #{sudo} umount /dev/xvdb || true", 'Unmounting /dev/xvdb')
-              # Setup RAID
-              log.debug 'Setting up RAID0'
-              ssh_exec!(ssh, "echo yes | #{sudo} mdadm --create /dev/md0 --level=0 --raid-devices=$(ls -1 /dev/xvd[b-z] | wc -l) $(ls -1 /dev/xvd[b-z])", 'Creating /dev/md0 RAID0 array')
-              if apt
-                ssh_exec!(ssh, "#{sudo} su - -c 'mdadm --detail --scan >> /etc/mdadm/mdadm.conf'", 'Write /etc/mdadm/mdadm.conf')
-              else
-                ssh_exec!(ssh, "#{sudo} su - -c 'mdadm --detail --scan >> /etc/mdadm.conf'", 'Write /etc/mdadm.conf')
-              end
-              ssh_exec!(ssh, "#{sudo} sed -i -e 's:xvdb:md0:' /etc/fstab", 'Update /etc/fstab for md0')
-              ssh_exec!(ssh, "#{sudo} /sbin/mkfs.ext4 /dev/md0 && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/md0 /data", 'Mounting /dev/md0 as /data')
-            elsif xvdb
-              ssh_exec!(ssh, "mount | grep ^/dev/xvdb 2>&1 >/dev/null && #{sudo} umount /dev/xvdb && #{sudo} /sbin/mkfs.ext4 /dev/xvdb && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/xvdb /data", 'Mounting /dev/xvdb as /data')
-            elsif xvda
-              ssh_exec!(ssh, "mount | grep ^/dev/xvda2 2>&1 >/dev/null && #{sudo} umount /dev/xvda2 && #{sudo} /sbin/mkfs.ext4 /dev/xvda2 && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/xvda2 /data", 'Mounting /dev/xvda2 as /data')
-            else
-              log.debug 'No additional instance store disks detected'
-            end
-            ssh_exec!(ssh, "#{sudo} sed -i -e 's:/mnt:/data:' /etc/fstab", 'Updating /etc/fstab for /data')
+        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, "#{sudo} hostname #{hostname}", "Setting hostname to #{hostname}")
+        # Setting up disks
+        log.debug 'Starting disk configuration'
+        if server.root_device_type == 'ebs'
+          log.debug 'EBS-backed instance detected...'
+          begin
+            extfs = true
+            ssh_exec!(ssh, "mount | grep xvde | awk '{print $5}' | grep -e 'ext[3-4]'", 'Checking filesystem')
+          rescue
+            extfs = false
           end
+          if extfs
+            log.debug 'File-system is EXT3/EXT4'
+            # resize2fs is safe to execute
+            ssh_exec!(ssh, "test -x /sbin/resize2fs && #{sudo} /sbin/resize2fs /dev/xvde", 'Resizing filesystem')
+          end
+        else
+          log.debug 'Instance store detected...'
+          begin
+            # m1.small uses /dev/xvda2 for data
+            xvda = true
+            xvdb = false
+            xvdc = false
+            ssh_exec!(ssh, 'test -e /dev/xvda2', 'Checking for /dev/xvda2')
+          rescue
+            xvda = false
+            begin
+              xvdb = true
+              ssh_exec!(ssh, 'test -e /dev/xvdb', 'Checking for /dev/xvdb')
+              # Do we have /dev/xvdc, too?
+              begin
+                xvdc = true
+                ssh_exec!(ssh, 'test -e /dev/xvdc', 'Checking for /dev/xvdc')
+              rescue
+                xvdc = false
+              end
+            rescue
+              xvdb = false
+            end
+          end
+
+          log.debug 'Found the following:'
+          log.debug "- xvda = #{xvda}"
+          log.debug "- xvdb = #{xvdb}"
+          log.debug "- xvdc = #{xvdc}"
+
+          # Now, do the right thing
+          if xvdc
+            # Check for APT
+            begin
+              apt = true
+              ssh_exec!(ssh, 'which apt-get', 'Checking for apt-get')
+            rescue
+              apt = false
+            end
+            # Install mdadm
+            if apt
+              ssh_exec!(ssh, "#{sudo} apt-get update", 'Running apt-get update')
+              # Setup nullmailer
+              ssh_exec!(ssh, "echo 'nullmailer shared/mailname string localhost' | #{sudo} debconf-set-selections && echo 'nullmailer nullmailer/relayhost string localhost' | #{sudo} debconf-set-selections", 'Configuring nullmailer')
+              ssh_exec!(ssh, "#{sudo} apt-get install nullmailer -y", 'Installing nullmailer')
+              ssh_exec!(ssh, "#{sudo} apt-get install mdadm -y", 'Installing mdadm')
+            else
+              ssh_exec!(ssh, "#{sudo} yum install mdadm -y", 'Installing mdadm')
+            end
+            ssh_exec!(ssh, "mount | grep ^/dev/xvdb 2>&1 >/dev/null && #{sudo} umount /dev/xvdb || true", 'Unmounting /dev/xvdb')
+            # Setup RAID
+            log.debug 'Setting up RAID0'
+            ssh_exec!(ssh, "echo yes | #{sudo} mdadm --create /dev/md0 --level=0 --raid-devices=$(ls -1 /dev/xvd[b-z] | wc -l) $(ls -1 /dev/xvd[b-z])", 'Creating /dev/md0 RAID0 array')
+            if apt
+              ssh_exec!(ssh, "#{sudo} su - -c 'mdadm --detail --scan >> /etc/mdadm/mdadm.conf'", 'Write /etc/mdadm/mdadm.conf')
+            else
+              ssh_exec!(ssh, "#{sudo} su - -c 'mdadm --detail --scan >> /etc/mdadm.conf'", 'Write /etc/mdadm.conf')
+            end
+            ssh_exec!(ssh, "#{sudo} sed -i -e 's:xvdb:md0:' /etc/fstab", 'Update /etc/fstab for md0')
+            ssh_exec!(ssh, "#{sudo} /sbin/mkfs.ext4 /dev/md0 && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/md0 /data", 'Mounting /dev/md0 as /data')
+          elsif xvdb
+            ssh_exec!(ssh, "mount | grep ^/dev/xvdb 2>&1 >/dev/null && #{sudo} umount /dev/xvdb && #{sudo} /sbin/mkfs.ext4 /dev/xvdb && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/xvdb /data", 'Mounting /dev/xvdb as /data')
+          elsif xvda
+            ssh_exec!(ssh, "mount | grep ^/dev/xvda2 2>&1 >/dev/null && #{sudo} umount /dev/xvda2 && #{sudo} /sbin/mkfs.ext4 /dev/xvda2 && #{sudo} mkdir -p /data && #{sudo} mount -o _netdev /dev/xvda2 /data", 'Mounting /dev/xvda2 as /data')
+          else
+            log.debug 'No additional instance store disks detected'
+          end
+          ssh_exec!(ssh, "#{sudo} sed -i -e 's:/mnt:/data:' /etc/fstab", 'Updating /etc/fstab for /data')
         end
       end
       # Return 0

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -114,14 +114,7 @@ class FogProviderOpenstack < Provider
       set_credentials(@task['config']['ssh-auth'])
       # Validate connectivity
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        # Backwards-compatibility... ssh_exec! takes 2 arguments prior to 0.9.8
-        ssho = method(:ssh_exec!)
-        if ssho.arity == 2
-          log.debug 'Validating external connectivity and DNS resolution via ping'
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com')
-        else
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
-        end
+        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
       end
       # Return 0
       @result['status'] = 0

--- a/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -111,17 +111,8 @@ class FogProviderRackspace < Provider
       set_credentials(@task['config']['ssh-auth'])
       # Validate connectivity and Mount data disk
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        # Backwards-compatibility... ssh_exec! takes 2 arguments prior to 0.9.8
-        ssho = method(:ssh_exec!)
-        if ssho.arity == 2
-          log.debug 'Validating external connectivity and DNS resolution via ping'
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com')
-          log.debug 'Mounting any additional data disks'
-          ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde1 /data) || true")
-        else
-          ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
-          ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde1 /data) || true", 'Mounting any additional data disks')
-        end
+        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde1 /data) || true", 'Mounting any additional data disks')
       end
       # Return 0
       @result['status'] = 0


### PR DESCRIPTION
The fog_provider plugin now requires 0.9.8 or better for full functionality. Due to this, removing compatibility for older releases from the plugin.
