### PR TITLE
Feature/epel

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/attributes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/attributes/default.rb
@@ -1,0 +1,1 @@
+default['base']['use_epel'] = true

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/metadata.rb
@@ -1,13 +1,14 @@
-name             "loom_base"
-maintainer       "Continuuity, Inc."
-maintainer_email "ops@continuuity.com"
-license          "Apache 2.0"
-description      "Base settings for all Loom hosts"
+name             'loom_base'
+maintainer       'Continuuity, Inc.'
+maintainer_email 'ops@continuuity.com'
+license          'Apache 2.0'
+description      'Base settings for all Loom hosts'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version          '0.1.1'
 
-depends "loom_hosts"
-depends "loom_firewall"
+depends 'loom_hosts'
+depends 'loom_firewall'
 
-depends "apt"
-depends "ulimit"
+depends 'apt'
+depends 'yum-epel'
+depends 'ulimit'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/recipes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/recipes/default.rb
@@ -20,12 +20,14 @@
 # This forces an apt-get update on Ubuntu/Debian
 case node['platform_family']
 when 'debian'
-  include_recipe "apt::default"
+  include_recipe 'apt::default'
+when 'rhel'
+  include_recipe 'yum-epel::default' if node['base']['use_epel'].to_s == 'true'
 end
 
 # We always run our hosts and firewall cookbooks
-include_recipe "loom_firewall::default"
-include_recipe "loom_hosts::default"
+include_recipe 'loom_firewall::default'
+include_recipe 'loom_hosts::default'
 
 # ensure user ulimits are enabled 
-include_recipe "ulimit::default"
+include_recipe 'ulimit::default'


### PR DESCRIPTION
Install EPEL repository on RHEL platforms. Can be overridden with `base['use_epel']` set to `false`... Fixes #542 
