### PR TITLE
Feature/ngui auth header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 script:
-  - "cd ngui && npm run travis"
-  - "cd .. && mvn test"
+  - "cd ngui && npm run travis && cd .. && mvn test"
+

--- a/ngui/README.md
+++ b/ngui/README.md
@@ -3,63 +3,50 @@ Coopr Angular UI
 
 ### for development:
 
-`cd standalone`
+first you need a server
 
-`mvn clean package assembly:single`
+* `cd standalone`
+* `mvn clean package assembly:single`
+* `open target` and unzip the _SNAPSHOT-standalone_ file
+* `LOOM_USE_DUMMY_PROVISIONER=true LOOM_DISABLE_UI=true target/(...)/bin/loom.sh start -f 50`
 
-`open target` and unzip the _SNAPSHOT-standalone_ file
+once that is running, to work on the frontend:
 
-`LOOM_USE_DUMMY_PROVISIONER=true LOOM_DISABLE_UI=true target/(...)/bin/loom.sh start -f 50`
-
-`cd ../ngui`
-
-`npm install && bower install` (assumes you have `bower` installed globally)
+* `cd ../ngui`
+* `npm install && bower install` (assumes you have `bower` installed globally)
 
 then, each in their own tab:
 
-`gulp watch` (autobuild + livereload)
+* `gulp watch` (autobuild + livereload)
+* `npm start` (http-server + cors-anywhere)
+* `npm test` (run karma for unit tests)
+* `open http://localhost:8080`
 
-`npm start` (http-server + cors-anywhere)
-
-`npm test` (run karma for unit tests)
-
-`open http://localhost:8080`
-
-* in dev mode, UI runs on port `8080` and connects to livereload on port `35729`
-* cors-anywhere runs on port `8081`
-* loom server is expected to be running on port `55054`
+in dev mode, UI runs on port `8080` and connects to livereload on port `35729`, cors-anywhere runs on port `8081`, and the loom server is expected to be running on port `55054`.
 
 ### for testing:
 
-`cd ngui`
-
-`npm run build` ( == `npm install && bower install && gulp build`)
-
-`npm run protractor` (end-to-end tests)
-
-`npm run test-single-run` (unit tests)
+* `cd ngui`
+* `npm run build` ( == `npm install && bower install && gulp build`)
+* `npm run test-single-run` (unit tests)
+* `npm run protractor` (end-to-end tests)
 
 protractor spins up a server on port `9090`
 
 ### for production:
 
-`cd ngui`
+generate a minified build of static assets, in the `ngui/dist/` folder
 
-`npm run build` ( == `npm install && bower install && gulp build`)
-
-`gulp minify`
-
-the above generates the `ngui/dist/` folder, which contains all static assets.
+* `cd ngui`
+* `npm run build` ( == `npm install && bower install && gulp build`)
+* `gulp minify`
 
 now to run the server, possibly on a different host:
 
-`cd ngui`
-
-`npm install --production` (will skip devDependencies)
-
-`export COOPR_UI_PORT=8100`
-
-`export COOPR_SERVER_URI=http://hostname:port`
-
-`npm start` or `node server.js`
+* `cd ngui`
+* `npm install --production` (will skip devDependencies)
+* `export COOPR_UI_PORT=8100`
+* `export COOPR_CORS_PORT=8101`
+* `export COOPR_SERVER_URI=http://hostname:port/v2/`
+* `npm start` or `node server.js`
 

--- a/ngui/app/index.html
+++ b/ngui/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" ng-app="coopr-ngui" ng-strict-di>
+<html lang="en" ng-strict-di>
 <head>
     <title ng-bind="$state.current | myTitleFilter">Coopr</title>
 
@@ -35,7 +35,6 @@
     </footer>
 
     <script type="text/javascript" src="/bundle/lib.js"></script>
-    <script type="text/javascript" src="/config.js"></script>
     <script type="text/javascript" src="/bundle/app.js"></script>
     <script type="text/javascript" src="/bundle/tpl.js"></script>
 

--- a/ngui/app/js/services/api.js
+++ b/ngui/app/js/services/api.js
@@ -50,7 +50,7 @@ module.factory('myApi', function(
 
 });
 
-module.config(function ($httpProvider, MYAPI_EVENT, MY_CONFIG) {
+module.config(function ($httpProvider, MYAPI_EVENT) {
   $httpProvider.interceptors.push(function ($q, $timeout, $rootScope, $log, myAuth, myApiPrefix) {
     var isApi = function(url) {
       return url.indexOf(myApiPrefix) === 0;

--- a/ngui/app/js/services/api.js
+++ b/ngui/app/js/services/api.js
@@ -50,7 +50,7 @@ module.factory('myApi', function(
 
 });
 
-module.config(function ($httpProvider, MYAPI_EVENT) {
+module.config(function ($httpProvider, MYAPI_EVENT, MY_CONFIG) {
   $httpProvider.interceptors.push(function ($q, $timeout, $rootScope, $log, myAuth, myApiPrefix) {
     var isApi = function(url) {
       return url.indexOf(myApiPrefix) === 0;
@@ -59,13 +59,24 @@ module.config(function ($httpProvider, MYAPI_EVENT) {
     return {
      'request': function(config) {
         if(isApi(config.url)) {
-          var u = myAuth.currentUser;
+
           angular.extend(config.headers, {
             'X-Requested-With': angular.version.codeName
-          }, u ? {
-            'X-Loom-UserID': u.username,
-            'X-Loom-TenantID': u.tenant
-          } : {});
+          });
+
+          if(myAuth.currentUser) {
+            angular.extend(config.headers, {
+              'X-Loom-UserID': myAuth.currentUser.username,
+              'X-Loom-TenantID': myAuth.currentUser.tenant
+            });
+          }
+
+          if(MY_CONFIG.authorization) {
+            angular.extend(config.headers, {
+              'Authorization': MY_CONFIG.authorization
+            });
+          }
+
           $log.log('[myApi]', config.method, config.url.substr(myApiPrefix.length));
         }
         return config;

--- a/ngui/app/js/services/api.js
+++ b/ngui/app/js/services/api.js
@@ -1,6 +1,6 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('MYAPI_PREFIX', function($location, MY_CONFIG){
+module.factory('myApiPrefix', function ($location, MY_CONFIG) {
 
   // to work with CORS proxy, we expect that the URI will include a port
   //  ... first we need to remove the protocol from the URI 
@@ -13,7 +13,7 @@ module.factory('MYAPI_PREFIX', function($location, MY_CONFIG){
 
        http :// host.foo.com : 8081 / otherhost.foo.com:55054/v2/
   */
-  return  $location.protocol() + '://' + $location.host() + 
+  return $location.protocol() + '://' + $location.host() + 
             ':' + MY_CONFIG.COOPR_CORS_PORT + '/' + restPath;
             
 });
@@ -50,10 +50,10 @@ module.factory('myApi', function(
 
 });
 
-module.config(function ($httpProvider) {
-  $httpProvider.interceptors.push(function ($q, $timeout, $rootScope, $log, myAuth, MYAPI_PREFIX, MYAPI_EVENT) {
+module.config(function ($httpProvider, MYAPI_EVENT, MY_CONFIG) {
+  $httpProvider.interceptors.push(function ($q, $timeout, $rootScope, $log, myAuth, myApiPrefix) {
     var isApi = function(url) {
-      return url.indexOf(MYAPI_PREFIX) === 0;
+      return url.indexOf(myApiPrefix) === 0;
     };
 
     return {
@@ -66,7 +66,7 @@ module.config(function ($httpProvider) {
             'X-Loom-UserID': u.username,
             'X-Loom-TenantID': u.tenant
           } : {});
-          $log.log('[myApi]', config.method, config.url.substr(MYAPI_PREFIX.length));
+          $log.log('[myApi]', config.method, config.url.substr(myApiPrefix.length));
         }
         return config;
       },

--- a/ngui/app/js/services/api/clusters.js
+++ b/ngui/app/js/services/api/clusters.js
@@ -1,36 +1,36 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_clusters', function($resource, MYAPI_PREFIX){
+module.factory('myApi_clusters', function($resource, myApiPrefix){
 
   return {
 
-    Cluster: $resource(MYAPI_PREFIX + 'clusters/:id',
+    Cluster: $resource(myApiPrefix + 'clusters/:id',
       { id: '@id' },
       { 
         getStatus: {
           method: 'GET',
-          url: MYAPI_PREFIX + 'clusters/:id/status'
+          url: myApiPrefix + 'clusters/:id/status'
         },
         startAllServices: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:id/services/start'
+          url: myApiPrefix + 'clusters/:id/services/start'
         },
         stopAllServices: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:id/services/stop'
+          url: myApiPrefix + 'clusters/:id/services/stop'
         },
         restartAllServices: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:id/services/restart'
+          url: myApiPrefix + 'clusters/:id/services/restart'
         },
         syncTemplate: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:id/clustertemplate/sync'
+          url: myApiPrefix + 'clusters/:id/clustertemplate/sync'
         }
       }
     ),
 
-    ClusterConfig: $resource(MYAPI_PREFIX + 'clusters/:clusterId/config',
+    ClusterConfig: $resource(myApiPrefix + 'clusters/:clusterId/config',
       {},
       {
         update: {
@@ -39,24 +39,24 @@ module.factory('myApi_clusters', function($resource, MYAPI_PREFIX){
       }
     ),
 
-    ClusterActionPlan: $resource(MYAPI_PREFIX + 'clusters/:clusterId/plans/:id',
+    ClusterActionPlan: $resource(myApiPrefix + 'clusters/:clusterId/plans/:id',
       { id: '@id' }
     ),
 
-    ClusterService: $resource(MYAPI_PREFIX + 'clusters/:clusterId/services/:name',
+    ClusterService: $resource(myApiPrefix + 'clusters/:clusterId/services/:name',
       { name: '@name' },
       { 
         start: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:clusterId/services/:name/start'
+          url: myApiPrefix + 'clusters/:clusterId/services/:name/start'
         },
         stop: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:clusterId/services/:name/stop'
+          url: myApiPrefix + 'clusters/:clusterId/services/:name/stop'
         },
         restart: {
           method: 'POST',
-          url: MYAPI_PREFIX + 'clusters/:clusterId/services/:name/restart'
+          url: myApiPrefix + 'clusters/:clusterId/services/:name/restart'
         }
       }
     )

--- a/ngui/app/js/services/api/hardwaretypes.js
+++ b/ngui/app/js/services/api/hardwaretypes.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_hardwaretypes', function($resource, MYAPI_PREFIX){
+module.factory('myApi_hardwaretypes', function($resource, myApiPrefix){
 
   return {
 
-    HardwareType: $resource(MYAPI_PREFIX + 'hardwaretypes/:name',
+    HardwareType: $resource(myApiPrefix + 'hardwaretypes/:name',
       { name: '@name' },
       { 
         update: {

--- a/ngui/app/js/services/api/imagetypes.js
+++ b/ngui/app/js/services/api/imagetypes.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_imagetypes', function($resource, MYAPI_PREFIX){
+module.factory('myApi_imagetypes', function($resource, myApiPrefix){
 
   return {
 
-    ImageType: $resource(MYAPI_PREFIX + 'imagetypes/:name',
+    ImageType: $resource(myApiPrefix + 'imagetypes/:name',
       { name: '@name' },
       { 
         update: {

--- a/ngui/app/js/services/api/importexport.js
+++ b/ngui/app/js/services/api/importexport.js
@@ -1,12 +1,12 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_importexport', function($resource, MYAPI_PREFIX){
+module.factory('myApi_importexport', function($resource, myApiPrefix){
 
   return {
 
-    Import: $resource(MYAPI_PREFIX + 'import'),
+    Import: $resource(myApiPrefix + 'import'),
 
-    Export: $resource(MYAPI_PREFIX + 'export', 
+    Export: $resource(myApiPrefix + 'export', 
       { }, 
       {
         query: {

--- a/ngui/app/js/services/api/providers.js
+++ b/ngui/app/js/services/api/providers.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_providers', function($resource, MYAPI_PREFIX){
+module.factory('myApi_providers', function($resource, myApiPrefix){
 
   return {
 
-    Provider: $resource(MYAPI_PREFIX + 'providers/:name',
+    Provider: $resource(myApiPrefix + 'providers/:name',
       { name: '@name' },
       { 
         update: {
@@ -13,7 +13,7 @@ module.factory('myApi_providers', function($resource, MYAPI_PREFIX){
       }
     ),
 
-    ProviderType: $resource(MYAPI_PREFIX + 'plugins/providertypes/:type')
+    ProviderType: $resource(myApiPrefix + 'plugins/providertypes/:type')
 
   };
 

--- a/ngui/app/js/services/api/provisioners.js
+++ b/ngui/app/js/services/api/provisioners.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_provisioners', function($resource, MYAPI_PREFIX){
+module.factory('myApi_provisioners', function($resource, myApiPrefix){
 
   return {
 
-    Provisioner: $resource(MYAPI_PREFIX + 'provisioners/:id',
+    Provisioner: $resource(myApiPrefix + 'provisioners/:id',
       { id: '@id' },
       {}
     )

--- a/ngui/app/js/services/api/services.js
+++ b/ngui/app/js/services/api/services.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_services', function($resource, MYAPI_PREFIX){
+module.factory('myApi_services', function($resource, myApiPrefix){
 
   return {
 
-    Service: $resource(MYAPI_PREFIX + 'services/:name',
+    Service: $resource(myApiPrefix + 'services/:name',
       { name: '@name' },
       { 
         update: {

--- a/ngui/app/js/services/api/templates.js
+++ b/ngui/app/js/services/api/templates.js
@@ -1,9 +1,9 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_templates', function($resource, MYAPI_PREFIX){
+module.factory('myApi_templates', function($resource, myApiPrefix){
 
   return {
-    Template: $resource(MYAPI_PREFIX + 'clustertemplates/:name',
+    Template: $resource(myApiPrefix + 'clustertemplates/:name',
       { name: '@name' },
       { 
         update: {

--- a/ngui/app/js/services/api/tenants.js
+++ b/ngui/app/js/services/api/tenants.js
@@ -1,10 +1,10 @@
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApi_tenants', function($resource, MYAPI_PREFIX){
+module.factory('myApi_tenants', function($resource, myApiPrefix){
 
   return {
 
-    Tenant: $resource(MYAPI_PREFIX + 'tenants/:name',
+    Tenant: $resource(myApiPrefix + 'tenants/:name',
       { name: '@name' },
       { 
         update: {

--- a/ngui/app/main.js
+++ b/ngui/app/main.js
@@ -115,7 +115,7 @@ angular
  * in all other cases we must fetch the config before bootstraping
  */
 try {
-  if(angular.injector([PKG.name+'.config'])) {
+  if(angular.injector([PKG.name+'.config'])) { // will throw if undefined
     start();
   }
 }

--- a/ngui/app/main.js
+++ b/ngui/app/main.js
@@ -112,16 +112,18 @@ angular
 
 /**
  * Config is already defined in test env,
- * in all other cases we must fetch the config
+ * in all other cases we must fetch the config before bootstraping
  */
 try {
-  angular.injector([PKG.name+'.config']) && start();
+  if(angular.injector([PKG.name+'.config'])) {
+    start();
+  }
 }
 catch(e) {
   angular.injector(['ng']).get('$http').get('/config.json')
     .then(function (response) {
       angular.module(PKG.name+'.config', [])
-        .constant("MY_CONFIG", response.data);
+        .constant('MY_CONFIG', response.data);
     })
     .then(start);
 }

--- a/ngui/app/main.js
+++ b/ngui/app/main.js
@@ -3,6 +3,9 @@ console.time(PKG.name);
 angular
   .module(PKG.name, [
 
+    angular.module(PKG.name+'.config', [
+    ]).name,
+
     angular.module(PKG.name+'.services', [
       PKG.name+'.config',
       'ngResource',
@@ -109,3 +112,18 @@ angular
       });
     });
   });
+
+/**
+ * Fetch config, then bootstrap the app
+ */
+angular.injector(['ng']).get('$http').get('/config.json').then(
+  function (response) {
+    angular.module(PKG.name+'.config').constant("MY_CONFIG", response.data);
+
+    angular.element(document).ready( function () {
+      angular.bootstrap(document, [PKG.name]);
+    });
+     
+  }
+);
+

--- a/ngui/app/main.js
+++ b/ngui/app/main.js
@@ -3,9 +3,6 @@ console.time(PKG.name);
 angular
   .module(PKG.name, [
 
-    angular.module(PKG.name+'.config', [
-    ]).name,
-
     angular.module(PKG.name+'.services', [
       PKG.name+'.config',
       'ngResource',
@@ -114,16 +111,25 @@ angular
   });
 
 /**
- * Fetch config, then bootstrap the app
+ * Config is already defined in test env,
+ * in all other cases we must fetch the config
  */
-angular.injector(['ng']).get('$http').get('/config.json').then(
-  function (response) {
-    angular.module(PKG.name+'.config').constant("MY_CONFIG", response.data);
+try {
+  angular.injector([PKG.name+'.config']) && start();
+}
+catch(e) {
+  angular.injector(['ng']).get('$http').get('/config.json')
+    .then(function (response) {
+      angular.module(PKG.name+'.config', [])
+        .constant("MY_CONFIG", response.data);
+    })
+    .then(start);
+}
 
-    angular.element(document).ready( function () {
-      angular.bootstrap(document, [PKG.name]);
-    });
-     
-  }
-);
+
+function start () {
+  angular.element(document).ready( function () {
+    angular.bootstrap(document, [PKG.name]);
+  });
+}
 

--- a/ngui/bower.json
+++ b/ngui/bower.json
@@ -2,12 +2,11 @@
   "name": "coopr-ngui",
   "private": true,
   "dependencies": {
-    "angular": "1.2.24",
-    "angular-sanitize": "~1.2.24",
-    "angular-mocks": "~1.2.24",
-    "angular-resource": "~1.2.24",
+    "angular": "~1.2.25",
+    "angular-sanitize": "~1.2.25",
+    "angular-mocks": "~1.2.25",
+    "angular-resource": "~1.2.25",
     "bootstrap": "~3.2.0",
-
     "angular-strap": "~2.1.0",
     "angular-ui-router": "~0.2.10",
     "ngstorage": "~0.3.0",
@@ -15,5 +14,8 @@
     "font-awesome": "~4.2.0",
     "es5-shim": "~4.0.3",
     "angular-moment": "~0.8.2"
+  },
+  "resolutions": {
+    "angular": "1.2.25"
   }
 }

--- a/ngui/server.js
+++ b/ngui/server.js
@@ -14,13 +14,17 @@ var pkg = require('./package.json'),
       hilite: function (v) { return '\x1B[7m' + v + '\x1B[27m'; },
       green: function (v) { return '\x1B[40m\x1B[32m' + v + '\x1B[39m\x1B[49m'; },
       pink: function (v) { return '\x1B[40m\x1B[35m' + v + '\x1B[39m\x1B[49m'; }
-    },
+    };
 
-    httpLabel = color.green('http-server'),
+
+var httpLabel = color.green('http-server'),
     corsLabel = color.pink('cors-proxy'),
-    httpLogger = morgan(httpLabel+' :method :url', {immediate: true}),
-    corsLogger = morgan(corsLabel+' :req[X-Loom-UserID]/:req[X-Loom-TenantID]' + 
-                                  ' :method :url '+color.hilite(':status'));
+    httpLogger = morgan(httpLabel+' :method :url', {
+      immediate: true
+    }),
+    corsLogger = morgan(corsLabel+' :method :url '+color.hilite(':status'), {
+      skip: function(req, res) { return req.method === 'OPTIONS' }
+    });
 
 console.log(color.hilite(pkg.name) + ' v' + pkg.version + ' starting up...');
 

--- a/ngui/server.js
+++ b/ngui/server.js
@@ -31,8 +31,6 @@ var color = {
 
 console.log(color.hilite(pkg.name) + ' v' + pkg.version + ' starting up...');
 
-var auth = require('basic-auth');
-
 /**
  * HTTP server
  */
@@ -41,17 +39,6 @@ require('http-server')
     root: __dirname + '/dist',
     before: [
       httpLogger,
-      function (req, res) {
-        var credentials = auth(req);
-        if (!credentials || credentials.name !== 'foo') {
-          res.writeHead(401, {
-            'WWW-Authenticate': 'Basic realm="foo"'
-          });
-          res.end()
-        } else {
-          res.emit('next');
-        }
-      },
       function (req, res) {
         if(req.url !== '/config.json') {
           // all other paths are passed to ecstatic

--- a/ngui/server.js
+++ b/ngui/server.js
@@ -6,23 +6,16 @@
 
 var pkg = require('./package.json'),
     morgan = require('morgan'),
+
     COOPR_UI_PORT = parseInt(process.env.COOPR_UI_PORT || 8080, 10),
     COOPR_CORS_PORT = parseInt(process.env.COOPR_CORS_PORT || 8081, 10),
 
-    configStr = JSON.stringify({
-      // the following will be available in angular via the "MY_CONFIG" injectable
-
-      COOPR_SERVER_URI: process.env.COOPR_SERVER_URI || 'http://127.0.0.1:55054/v2/',
-      COOPR_CORS_PORT: COOPR_CORS_PORT
-
-    });
-
-
-var color = {
+    color = {
       hilite: function (v) { return '\x1B[7m' + v + '\x1B[27m'; },
       green: function (v) { return '\x1B[40m\x1B[32m' + v + '\x1B[39m\x1B[49m'; },
       pink: function (v) { return '\x1B[40m\x1B[35m' + v + '\x1B[39m\x1B[49m'; }
     },
+
     httpLabel = color.green('http-server'),
     corsLabel = color.pink('cors-proxy'),
     httpLogger = morgan(httpLabel+' :method :url', {immediate: true}),
@@ -48,7 +41,14 @@ require('http-server')
           'Content-Type': 'application/json',
           'Cache-Control': 'no-store, must-revalidate'
         });
-        res.end(configStr); 
+        res.end(JSON.stringify({
+          // the following will be available in angular via the "MY_CONFIG" injectable
+
+          COOPR_SERVER_URI: process.env.COOPR_SERVER_URI || 'http://127.0.0.1:55054/v2/',
+          COOPR_CORS_PORT: COOPR_CORS_PORT,
+          authorization: req.headers.authorization
+
+        }));
       }
     ]
   })

--- a/ngui/server.js
+++ b/ngui/server.js
@@ -17,12 +17,14 @@ var pkg = require('./package.json'),
     };
 
 
+morgan.token('loomcred', function(req, res){ 
+  return color.pink(req.headers['x-loom-userid'] + '/' + req.headers['x-loom-tenantid']); 
+});
+
 var httpLabel = color.green('http-server'),
     corsLabel = color.pink('cors-proxy'),
-    httpLogger = morgan(httpLabel+' :method :url', {
-      immediate: true
-    }),
-    corsLogger = morgan(corsLabel+' :method :url '+color.hilite(':status'), {
+    httpLogger = morgan(httpLabel+' :method :url', {immediate: true}),
+    corsLogger = morgan(corsLabel+' :method :url :loomcred :status', {
       skip: function(req, res) { return req.method === 'OPTIONS' }
     });
 

--- a/ngui/test/config.js
+++ b/ngui/test/config.js
@@ -1,5 +1,4 @@
-angular.module("coopr-ngui.config", []).constant("MY_CONFIG", {
+angular.module("coopr-ngui.config").constant("MY_CONFIG", {
   "COOPR_SERVER_URI": "http://127.0.0.1:55054/v2/",
-  "COOPR_CORS_PORT": 8081,
-  "COOPR_UI_PORT": 8080
+  "COOPR_CORS_PORT": 8081
 });

--- a/ngui/test/config.js
+++ b/ngui/test/config.js
@@ -1,4 +1,4 @@
-angular.module("coopr-ngui.config").constant("MY_CONFIG", {
+angular.module("coopr-ngui.config", []).constant("MY_CONFIG", {
   "COOPR_SERVER_URI": "http://127.0.0.1:55054/v2/",
   "COOPR_CORS_PORT": 8081
 });

--- a/ngui/test/config.js
+++ b/ngui/test/config.js
@@ -1,4 +1,5 @@
 angular.module("coopr-ngui.config", []).constant("MY_CONFIG", {
   "COOPR_SERVER_URI": "http://127.0.0.1:55054/v2/",
-  "COOPR_CORS_PORT": 8081
+  "COOPR_CORS_PORT": 8081,
+  "autorization": "respect my authoritah"
 });

--- a/ngui/test/unit/services/api.spec.js
+++ b/ngui/test/unit/services/api.spec.js
@@ -4,11 +4,12 @@ describe('service', function() {
   beforeEach(module('coopr-ngui.services'));
 
   describe('myApi', function() {
-    var myApi, myAuth, $rootScope, $httpBackend;
+    var myApi, myAuth, MY_CONFIG, $rootScope, $httpBackend;
 
     beforeEach(inject(function($injector) {
       myApi = $injector.get('myApi');
       myAuth = $injector.get('myAuth');
+      MY_CONFIG = $injector.get('MY_CONFIG');
       $rootScope = $injector.get('$rootScope');
       $httpBackend = $injector.get('$httpBackend');
     }));
@@ -49,6 +50,15 @@ describe('service', function() {
         item.$get();
         $httpBackend.flush();
         expect(item.foo).toEqual('bar');
+      });
+
+      it('should send Authorization header', function() {
+        $httpBackend.expectGET(/v2\/clusters$/, function(headers) {
+          return headers['Authorization'] === MY_CONFIG.authorization;
+        }).respond(201, '');
+
+        myApi.Cluster.query();
+        $httpBackend.flush();
       });
 
       it('should send X-Requested-With header', function() {


### PR DESCRIPTION
follow-up to #562 re #554
- renames MYAPI_PREFIX to myApiPrefix, because although we use it as a constant, it is a factory and hence not injectable in config blocks.
- delays app bootstrap until we fetch /config.json, which contains runtime config + gives us the authorization header to use on API calls.

@wolf31o2 I believe this implements what we discussed today over hipchat regarding sharing the reverse-proxy auth with CORS port.
