### PR TITLE
include config/[hostname/ipaddresses] in merged chef json

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -98,6 +98,7 @@ class ChefSoloAutomator < Automator
     # include the hostname and clusterId
     servicedata['loom']['hostname'] = @task['config']['hostname']
     servicedata['loom']['clusterId'] = @task['clusterId']
+    servicedata['loom']['ipaddresses'] = @task['config']['ipaddresses']
 
     # we also need to merge cluster config top-level
     servicedata.merge!(clusterdata)

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -95,7 +95,8 @@ class ChefSoloAutomator < Automator
     servicedata['loom']['cluster'] = clusterdata
     servicedata['loom']['services'] = node_services_data
 
-    # include the clusterId
+    # include the hostname and clusterId
+    servicedata['loom']['hostname'] = @task['config']['hostname']
     servicedata['loom']['clusterId'] = @task['clusterId']
 
     # we also need to merge cluster config top-level

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -95,7 +95,7 @@ class ChefSoloAutomator < Automator
     servicedata['loom']['cluster'] = clusterdata
     servicedata['loom']['services'] = node_services_data
 
-    # include the hostname and clusterId
+    # include additional node attributes not present in the cluster config
     servicedata['loom']['hostname'] = @task['config']['hostname']
     servicedata['loom']['clusterId'] = @task['clusterId']
     servicedata['loom']['ipaddresses'] = @task['config']['ipaddresses']


### PR DESCRIPTION
when chef-solo automator transforms task json into chef json, it will now populate `{"loom": { "hostname": "foo" }, "ipaddresses": { } }`
