### PR TITLE
Add DNS support to loom_base

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.gitignore
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.gitignore
@@ -1,0 +1,7 @@
+.bundle
+.cache
+.kitchen/
+.kitchen.local.yml
+bin
+Berksfile.lock
+Gemfile.lock

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.kitchen.yml
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: centos-6.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[dnsimple::default]
+    attributes:

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.travis.yml
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+bundler_args: --without development integration
+rvm:
+  - 1.9.3
+  - 2.0.0
+before_install:
+  - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+before_script:
+  - bundle exec berks install
+script: bundle exec rspec spec

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/Gemfile
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+group :test do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'chefspec', '~> 3.0'
+  gem 'serverspec'
+  gem 'fog', :git => 'https://github.com/fog/fog'
+  gem 'berkshelf'
+end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/LICENSE
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/README.md
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/README.md
@@ -1,0 +1,110 @@
+## Description
+
+A Light-weight Resource and Provider (LWRP) supporting
+automatic DNS configuration via DNSimple's API.
+
+## Changes
+
+[![Build Status](https://travis-ci.org/aetrion/chef-dnsimple.png?branch=master)](https://travis-ci.org/aetrion/chef-dnsimple)
+
+* Add [Test Kitchen](http://kitchen.ci)
+* Change method of disabling Excon's peer verification.
+* Convert README to markdown so it is displayed nice on Community
+  site.
+* Add default action `:create` for `dnsimple_record`.
+* Set values that `type` can be equal to in `dnsimple_record` resource.
+
+## Requirements
+
+A DNSimple account at http://dnsimple.com
+
+## Attributes
+
+All attributes are `nil`, or `false` by default.
+
+- `node[:dnsimple][:username]`: Your DNSimple login username.
+- `node[:dnsimple][:password]`: Your DNSimple login password.
+- `node[:dnsimple][:domain]`: The domain that this node should use.
+- `node[:dnsimple][:test]`: Unused at this time.
+
+## Resources/Providers
+
+dnsimple\_record
+----------------
+
+Manage a DNS resource record through the DNSimple API. This LWRP uses
+the [fog Ruby library](http://rubygems.org/gems/fog) to connect and
+use the API.
+
+### Actions:
+
+    | Action    | Description          | Default |
+    |-----------|----------------------|---------|
+    | *create*  | Create the record.   | Yes     |
+    | *destroy* | Destroy the record.  |         |
+
+### Parameter Attributes:
+
+The type of record can be one of the following: A, CNAME, ALIAS, MX,
+SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
+
+    | Parameter  | Description                | Default |
+    |------------|----------------------------|---------|
+    | *domain*   | Domain to manage           |         |
+    | *name*     | _Name_: Name of the record |         |
+    | *type*     | Type of DNS record         |         |
+    | *content*  | String content of record   |         |
+    | *ttl*      | Time to live.              | 3600    |
+    | *priority* | Priorty of update          |         |
+    | *username* | DNSimple username          |         |
+    | *password* | DNSimple password          |         |
+    | *test*     | Unused at this time        | false   |
+
+### Examples
+
+    dnsimple_record "create an A record" do
+      name     "test"
+      content  "16.8.4.2"
+      type     "A"
+      domain   node[:dnsimple][:domain]
+      username node[:dnsimple][:username]
+      password node[:dnsimple][:password]
+      action   :create
+    end
+
+    dnsimple_record "create a CNAME record for a Google Apps site calendar" do
+      name     "calendar"
+      content  "ghs.google.com"
+      type     "CNAME"
+      domain   node[:dnsimple][:domain]
+      username node[:dnsimple][:username]
+      password node[:dnsimple][:password]
+      action   :create
+    end
+
+## Usage
+
+Add the the `dnsimple` recipe to a node's run list, or with
+`include_recipe` to install the [fog](http://rubygems.org/gems/fog)
+gem, which is used to interact with the DNSimple API. See
+examples of the LWRP usage above.
+
+## License and Author
+
+* Author:: [Darrin Eden](https://github.com/dje)
+* Author:: [Joshua Timberman](https://github.com/jtimberman)
+* Author:: [Jose Luis Salas](https://github.com/josacar)
+
+Copyright:: 2014 Aetrion LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/attributes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/attributes/default.rb
@@ -1,0 +1,19 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+override[:build_essential][:compiletime] = true
+

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/attributes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/attributes/dnsimple.rb
@@ -1,0 +1,21 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:dnsimple][:username] = nil # DNSimple username
+default[:dnsimple][:password] = nil # DNSimple password
+default[:dnsimple][:domain] = nil   # Default domain to use
+default[:dnsimple][:fog_version] = "1.6.0" # Default version of fog to install

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/libraries/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/libraries/dnsimple.rb
@@ -1,0 +1,16 @@
+begin
+  require "fog/dnsimple"
+  Excon.defaults[:ssl_verify_peer] = true
+rescue LoadError
+  Chef::Log.warn("Missing gem 'fog'")
+end
+
+module DNSimple
+  module Connection
+    def dnsimple
+      @@dnsimple ||= Fog::DNS.new( :provider => "DNSimple",
+                                   :dnsimple_email => new_resource.username,
+                                   :dnsimple_password => new_resource.password )
+    end
+  end
+end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/metadata.json
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/metadata.json
@@ -1,0 +1,38 @@
+{
+  "name": "dnsimple",
+  "description": "Installs/Configures dnsimple",
+  "long_description": "## Description\n\nA Light-weight Resource and Provider (LWRP) supporting\nautomatic DNS configuration via DNSimple's API.\n\n## Changes\n\n[![Build Status](https://travis-ci.org/aetrion/chef-dnsimple.png?branch=master)](https://travis-ci.org/aetrion/chef-dnsimple)\n\n* Add [Test Kitchen](http://kitchen.ci)\n* Change method of disabling Excon's peer verification.\n* Convert README to markdown so it is displayed nice on Community\n  site.\n* Add default action `:create` for `dnsimple_record`.\n* Set values that `type` can be equal to in `dnsimple_record` resource.\n\n## Requirements\n\nA DNSimple account at http://dnsimple.com\n\n## Attributes\n\nAll attributes are `nil`, or `false` by default.\n\n- `node[:dnsimple][:username]`: Your DNSimple login username.\n- `node[:dnsimple][:password]`: Your DNSimple login password.\n- `node[:dnsimple][:domain]`: The domain that this node should use.\n- `node[:dnsimple][:test]`: Unused at this time.\n\n## Resources/Providers\n\ndnsimple\\_record\n----------------\n\nManage a DNS resource record through the DNSimple API. This LWRP uses\nthe [fog Ruby library](http://rubygems.org/gems/fog) to connect and\nuse the API.\n\n### Actions:\n\n    | Action    | Description          | Default |\n    |-----------|----------------------|---------|\n    | *create*  | Create the record.   | Yes     |\n    | *destroy* | Destroy the record.  |         |\n\n### Parameter Attributes:\n\nThe type of record can be one of the following: A, CNAME, ALIAS, MX,\nSPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.\n\n    | Parameter  | Description                | Default |\n    |------------|----------------------------|---------|\n    | *domain*   | Domain to manage           |         |\n    | *name*     | _Name_: Name of the record |         |\n    | *type*     | Type of DNS record         |         |\n    | *content*  | String content of record   |         |\n    | *ttl*      | Time to live.              | 3600    |\n    | *priority* | Priorty of update          |         |\n    | *username* | DNSimple username          |         |\n    | *password* | DNSimple password          |         |\n    | *test*     | Unused at this time        | false   |\n\n### Examples\n\n    dnsimple_record \"create an A record\" do\n      name     \"test\"\n      content  \"16.8.4.2\"\n      type     \"A\"\n      domain   node[:dnsimple][:domain]\n      username node[:dnsimple][:username]\n      password node[:dnsimple][:password]\n      action   :create\n    end\n\n    dnsimple_record \"create a CNAME record for a Google Apps site calendar\" do\n      name     \"calendar\"\n      content  \"ghs.google.com\"\n      type     \"CNAME\"\n      domain   node[:dnsimple][:domain]\n      username node[:dnsimple][:username]\n      password node[:dnsimple][:password]\n      action   :create\n    end\n\n## Usage\n\nAdd the the `dnsimple` recipe to a node's run list, or with\n`include_recipe` to install the [fog](http://rubygems.org/gems/fog)\ngem, which is used to interact with the DNSimple API. See\nexamples of the LWRP usage above.\n\n## License and Author\n\n* Author:: [Darrin Eden](https://github.com/dje)\n* Author:: [Joshua Timberman](https://github.com/jtimberman)\n* Author:: [Jose Luis Salas](https://github.com/josacar)\n\nCopyright:: 2014 Aetrion LLC\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+  "maintainer": "DNSimple",
+  "maintainer_email": "ops@dnsimple.com",
+  "license": "Apache 2.0",
+  "platforms": {
+    "amazon": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "debian": ">= 0.0.0",
+    "fedora": ">= 0.0.0",
+    "redhat": ">= 0.0.0",
+    "rhel": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0"
+  },
+  "dependencies": {
+    "build-essential": "~> 1.4.2"
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+    "dnsimple": "Installs fog gem to use w/ the dnsimple_record"
+  },
+  "version": "1.0.0"
+}

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/metadata.rb
@@ -1,0 +1,19 @@
+name             'dnsimple'
+maintainer       'DNSimple'
+maintainer_email 'ops@dnsimple.com'
+license          'Apache 2.0'
+description      'Installs/Configures dnsimple'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '1.0.0'
+
+recipe   'dnsimple', 'Installs fog gem to use w/ the dnsimple_record'
+
+supports 'amazon'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'redhat'
+supports 'rhel'
+supports 'ubuntu'
+
+depends 'build-essential', '~> 1.4.2'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/providers/record.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/providers/record.rb
@@ -1,0 +1,101 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# Copyright:: Copyright (c) 2012, Joshua Timberman
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include DNSimple::Connection
+
+def whyrun_supported?
+  true
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::DnsimpleRecord.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  @current_resource.domain(@new_resource.domain)
+
+  @current_resource.exists = check_for_record
+end
+
+action :create do
+  case @current_resource.exists
+  when :same
+    Chef::Log.info "#{ @new_resource } already exists - nothing to do."
+  when :different
+    converge_by("Updating #{ @new_resource }") do
+      delete_record
+      create_record
+    end
+  when :none
+    converge_by("Creating #{ @new_resource }") do
+      create_record
+    end
+  end
+end
+
+action :destroy do
+  delete_record
+end
+
+def check_for_record
+  all_records_in_zone do |r|
+    if ((r.name == new_resource.name) && (r.type == new_resource.type))
+      if ((r.value == new_resource.content) && (r.ttl == new_resource.ttl))
+        return :same
+      else
+        return :different
+      end
+    end
+  end
+  return :none
+end
+
+def create_record
+  Chef::Log.debug "Attempting to create record type #{new_resource.type} for #{new_resource.name} as #{new_resource.content} with type #{new_resource.type}"
+  zone = dnsimple.zones.get( new_resource.domain )
+  record = zone.records.create( :name  => new_resource.name,
+                               :value => new_resource.content,
+                               :type  => new_resource.type,
+                               :ttl   => new_resource.ttl )
+  new_resource.updated_by_last_action(true)
+  Chef::Log.info "DNSimple: created #{new_resource.type} record for #{new_resource.name}.#{new_resource.domain}"
+rescue Excon::Errors::UnprocessableEntity
+  Chef::Log.debug "DNSimple: #{new_resource.name}.#{new_resource.domain} already exists, moving on"
+end
+
+def delete_record
+  if [:same, :different].include?(@current_resource.exists)
+    all_records_in_zone do |r|
+      if (( r.name == new_resource.name ) && ( r.type == new_resource.type ))
+        r.destroy
+        new_resource.updated_by_last_action(true)
+        Chef::Log.info "DNSimple: destroyed #{new_resource.type} record " +
+          "for #{new_resource.name}.#{new_resource.domain}"
+      end
+    end
+  else
+    Chef::Log.info "DNSimple: no record found #{new_resource.name}.#{new_resource.domain}" +
+      " with type #{new_resource.type}"
+  end
+end
+
+def all_records_in_zone
+  zone = dnsimple.zones.get( new_resource.domain )
+
+  zone.records.all.each do |r|
+     yield r if block_given?
+  end
+end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/recipes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/recipes/default.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: dnsimple
+# Recipe:: default
+#
+# Copyright 2014, Aetrion LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'build-essential'
+
+value_for_platform_family(
+  'debian' => ['libxml2-dev', 'libxslt1-dev'],
+  'rhel' => ['libxml2-devel', 'libxslt-devel'],
+).each do |pkg|
+  r = package( pkg ) { action :nothing }
+  r.run_action( :install )
+end
+
+chef_gem 'fog' do
+  version node['dnsimple']['fog_version']
+  action :install
+end
+
+require 'fog'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/resources/record.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/dnsimple/resources/record.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2010-2011, Heavy Water Software
+# Copyright:: Copyright (c) 2011, Joshua Timberman
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :destroy
+
+default_action :create
+
+attribute :domain,   :kind_of => String
+attribute :name,     :kind_of => String
+attribute :type,     :kind_of => String, :equal_to => ["A", "CNAME", "ALIAS", "MX", "SPF", "URL", "TXT", "NS", "SRV", "NAPTR", "PTR", "AAA", "SSHFP", "HFINO"]
+attribute :content,  :kind_of => String
+attribute :ttl,      :kind_of => Integer, :default => 3600
+attribute :priority, :kind_of => Integer
+attribute :username, :kind_of => String
+attribute :password, :kind_of => String
+
+attr_accessor :exists

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/metadata.rb
@@ -4,10 +4,11 @@ maintainer_email 'ops@continuuity.com'
 license          'Apache 2.0'
 description      'Base settings for all Loom hosts'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'
 
-depends 'loom_hosts'
+depends 'loom_dns'
 depends 'loom_firewall'
+depends 'loom_hosts'
 
 depends 'apt'
 depends 'yum-epel'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/recipes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/recipes/default.rb
@@ -25,9 +25,10 @@ when 'rhel'
   include_recipe 'yum-epel::default' if node['base']['use_epel'].to_s == 'true'
 end
 
-# We always run our hosts and firewall cookbooks
-include_recipe 'loom_firewall::default'
-include_recipe 'loom_hosts::default'
+# We always run our dns, firewall, and hosts cookbooks
+%w(dns firewall hosts).each do |cb|
+  include_recipe "loom_#{cb}::default"
+end
 
 # ensure user ulimits are enabled 
 include_recipe 'ulimit::default'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/default.rb
@@ -1,0 +1,3 @@
+default['loom_dns']['provider'] = nil
+default['loom_dns']['default_domain'] = nil
+default['loom_dns']['default_ttl'] = 600

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
@@ -1,0 +1,12 @@
+# We need to build early
+default['build_essential']['compiletime'] = true
+default['build-essential']['compiletime'] = true
+# Specify a fog version
+default['dnsimple']['fog_version'] = '1.21.0'
+# Our configuration
+default['loom_dns']['dnsimple']['use_databag'] = true
+default['loom_dns']['dnsimple']['databag_name'] = 'creds'
+default['loom_dns']['dnsimple']['databag_item'] = 'dnsimple'
+# The following attributes can be used in place of a data bag
+default['loom_dns']['dnsimple']['username'] = nil
+default['loom_dns']['dnsimple']['password'] = nil

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
@@ -1,6 +1,5 @@
 # Specify a fog version
 default['dnsimple']['fog_version'] = '1.21.0'
 # Our configuration
-default['loom_dns']['dnsimple']['use_databag'] = true
 default['loom_dns']['dnsimple']['databag_name'] = 'creds'
 default['loom_dns']['dnsimple']['databag_item'] = 'dnsimple'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/attributes/dnsimple.rb
@@ -1,12 +1,6 @@
-# We need to build early
-default['build_essential']['compiletime'] = true
-default['build-essential']['compiletime'] = true
 # Specify a fog version
 default['dnsimple']['fog_version'] = '1.21.0'
 # Our configuration
 default['loom_dns']['dnsimple']['use_databag'] = true
 default['loom_dns']['dnsimple']['databag_name'] = 'creds'
 default['loom_dns']['dnsimple']['databag_item'] = 'dnsimple'
-# The following attributes can be used in place of a data bag
-default['loom_dns']['dnsimple']['username'] = nil
-default['loom_dns']['dnsimple']['password'] = nil

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/metadata.rb
@@ -1,6 +1,6 @@
 name             'loom_dns'
-maintainer       'Cask'
-maintainer_email 'ops@cask.co'
+maintainer       'Continuuity'
+maintainer_email 'ops@continuuity.com'
 license          'All rights reserved'
 description      'Installs/Configures DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/metadata.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/metadata.rb
@@ -1,0 +1,10 @@
+name             'loom_dns'
+maintainer       'Cask'
+maintainer_email 'ops@cask.co'
+license          'All rights reserved'
+description      'Installs/Configures DNS'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'dnsimple'
+depends 'build-essential'

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/default.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: loom_dns
+# Recipe:: default
+#
+# Copyright (C) 2013-2014 Continuuity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node['loom_dns']['provider'].nil?
+  include_recipe "loom_dns::#{node['loom_dns']['provider']}"
+end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/default.rb
@@ -19,4 +19,6 @@
 
 unless node['loom_dns']['provider'].nil?
   include_recipe "loom_dns::#{node['loom_dns']['provider']}"
+else
+  Chef::Log.warn('No DNS provider configured, skipping DNS registration')
 end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
@@ -21,14 +21,17 @@
   include_recipe recipe
 end
 
-if node['loom_dns']['dnsimple']['use_databag']
-  bag = node['loom_dns']['dnsimple']['databag_name']
-  item = node['loom_dns']['dnsimple']['databag_item']
-  dnsimple = data_bag_item(bag, item)
-elsif node['dnsimple']['username'] && node['dnsimple']['password']
+# Get credentials
+if node['dnsimple']['username'] && node['dnsimple']['password']
   dnsimple = node['dnsimple']
 else
-  Chef::Application.fatal!('You must specify either a data bag or username/password!')
+  begin
+    bag = node['loom_dns']['dnsimple']['databag_name']
+    item = node['loom_dns']['dnsimple']['databag_item']
+    dnsimple = data_bag_item(bag, item)
+  rescue
+    Chef::Application.fatal!('You must specify either a data bag or username/password!')
+  end
 end
 
 # Setup some variables

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
@@ -1,0 +1,56 @@
+#
+# Cookbook Name:: loom_dns
+# Recipe:: dnsimple
+#
+# Copyright (C) 2013-2014 Continuuity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+%w(build-essential dnsimple).each do |recipe|
+  include_recipe recipe
+end
+
+if node['loom_dns']['dnsimple']['use_databag']
+  bag = node['loom_dns']['dnsimple']['databag_name']
+  item = node['loom_dns']['dnsimple']['databag_item']
+  dnsimple = data_bag_item(bag, item)
+elsif node['loom_dns']['dnsimple']['username'] && node['loom_dns']['dnsimple']['password']
+  dnsimple['username'] = node['loom_dns']['dnsimple']['username']
+  dnsimple['password'] = node['loom_dns']['dnsimple']['password']
+else
+  Chef::Application.fatal!('You must specify either a data bag or username/password!')
+end
+
+# Setup some variables
+fqdn = node['loom']['hostname'] ? node['loom']['hostname'] : node['fqdn']
+hostname = fqdn.split('.').first
+subdomain = fqdn.split('.', 2).last
+access_v4 = node['loom']['ipaddresses']['access_v4'] ? node['loom']['ipaddresses']['access_v4'] : node['ipaddress']
+
+# Do not register "private" domains
+case subdomain
+when 'local', 'novalocal', 'internal'
+  subdomain = node['loom_dns']['default_domain'] ? node['loom_dns']['default_domain'] : 'local'
+end
+
+# Create DNS entries for access_v4
+dnsimple_record hostname do
+  content access_v4
+  type 'A'
+  username dnsimple['username']
+  password dnsimple['password']
+  domain subdomain
+  ttl node['loom_dns']['default_ttl']
+  not_if { subdomain = 'local' }
+end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
@@ -26,8 +26,7 @@ if node['loom_dns']['dnsimple']['use_databag']
   item = node['loom_dns']['dnsimple']['databag_item']
   dnsimple = data_bag_item(bag, item)
 elsif node['dnsimple']['username'] && node['dnsimple']['password']
-  dnsimple['username'] = node['dnsimple']['username']
-  dnsimple['password'] = node['dnsimple']['password']
+  dnsimple = node['dnsimple']
 else
   Chef::Application.fatal!('You must specify either a data bag or username/password!')
 end

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
@@ -25,9 +25,9 @@ if node['loom_dns']['dnsimple']['use_databag']
   bag = node['loom_dns']['dnsimple']['databag_name']
   item = node['loom_dns']['dnsimple']['databag_item']
   dnsimple = data_bag_item(bag, item)
-elsif node['loom_dns']['dnsimple']['username'] && node['loom_dns']['dnsimple']['password']
-  dnsimple['username'] = node['loom_dns']['dnsimple']['username']
-  dnsimple['password'] = node['loom_dns']['dnsimple']['password']
+elsif node['dnsimple']['username'] && node['dnsimple']['password']
+  dnsimple['username'] = node['dnsimple']['username']
+  dnsimple['password'] = node['dnsimple']['password']
 else
   Chef::Application.fatal!('You must specify either a data bag or username/password!')
 end


### PR DESCRIPTION
Currently, we only support dnsimple, but any DNS provider which can be modified via API can be added. By default, this does nothing, so it's safe to add everywhere. To use this, a user would need to add JSON to his `base` service in Loom such as:

``` json
{"loom_dns":{"provider":"dnsimple"}}
```

This would require the use of a `creds` data bag with a `dnsimple` item. These are configurable, and someone can choose to provide an username/password combo, instead.

``` json
{"loom_dns":{"provider":"dnsimple","dnsimple":{"use_databag":false}},"dnsimple":{"username":USERNAME,"password":PASSWORD}}
```
