### PR TITLE
run apt-update at compile time in case there are other recipes

### DIFF
--- a/config/defaults/services/base.json
+++ b/config/defaults/services/base.json
@@ -18,6 +18,7 @@
       "install": {
         "type": "chef-solo",
         "fields": {
+          "json_attributes": "{\"apt\":{\"compile_time_update\":\"true\"}}",
           "run_list": "recipe[loom_base::default]"
         }
       },


### PR DESCRIPTION
like the dnsimple recipe that will try to get packages at compile
time.
