### PR TITLE
Move apt.compile_time_update from template to cookbook

### DIFF
--- a/config/defaults/services/base.json
+++ b/config/defaults/services/base.json
@@ -18,7 +18,6 @@
       "install": {
         "type": "chef-solo",
         "fields": {
-          "json_attributes": "{\"apt\":{\"compile_time_update\":\"true\"}}",
           "run_list": "recipe[loom_base::default]"
         }
       },

--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/attributes/default.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_base/attributes/default.rb
@@ -1,1 +1,2 @@
 default['base']['use_epel'] = true
+default['apt']['compile_time_update'] = true


### PR DESCRIPTION
This allows it to be overridden, if necessary. Another cookbook can set `override['apt']['compile_time_update'] = false` to override.
