### PR TITLE
Feature/no provider dns

### DIFF
--- a/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
+++ b/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks/loom_dns/recipes/dnsimple.rb
@@ -44,6 +44,9 @@ access_v4 = node['loom']['ipaddresses']['access_v4'] ? node['loom']['ipaddresses
 case subdomain
 when 'local', 'novalocal', 'internal'
   subdomain = node['loom_dns']['default_domain'] ? node['loom_dns']['default_domain'] : 'local'
+else
+  # Do not register provider-based domains
+  subdomain = 'provider' if subdomain =~ /amazonaws.com$/
 end
 
 # Only register whitelisted subdomains if they are set
@@ -58,6 +61,6 @@ if subdomain_whitelist.nil? || subdomain_whitelist.include?(subdomain)
     password dnsimple['password']
     domain subdomain
     ttl node['loom_dns']['default_ttl']
-    not_if { subdomain == 'local' }
+    not_if { subdomain == 'local' || subdomain == 'provider' }
   end
 end


### PR DESCRIPTION
This allows for not registering DNS when there is a provider-specific hostname. Currently, only AWS has externally-resolvable hostnames.
