### PR TITLE
fix titles for ui pages so that the product name is used instead

### DIFF
--- a/ui/client/templates/imagetypes/imagetypes.html
+++ b/ui/client/templates/imagetypes/imagetypes.html
@@ -1,6 +1,6 @@
 {% extends 'index.html' %}
 
-{% block title %}Create Image Type{% endblock %}
+{% block title %}Image Types{% endblock %}
 
 {% block header %}
     {% include "page-header.html" %}

--- a/ui/client/templates/index.html
+++ b/ui/client/templates/index.html
@@ -46,7 +46,7 @@
         <script type="text/javascript" src="/static/third_party/jquery-textrange.js"></script>
         {% block headscript %}{% endblock %}
         <script src="/static/js/helpers.js" type="text/javascript"></script>
-        <title>{% block title %}Loom{% endblock %} | Continuuity</title>
+        <title>{% block title %}Overview{% endblock %} | Loom</title>
     </head>
     <body>
     {% block body %}


### PR DESCRIPTION
of the company name, and the image types page is properly named.
