### PR TITLE
Update imagetypes for Shellshock

### DIFF
--- a/coopr-server/config/defaults/imagetypes/centos6.json
+++ b/coopr-server/config/defaults/imagetypes/centos6.json
@@ -18,7 +18,7 @@
       "image": "bf67d2fc-2ed1-11e4-a6ef-a7df3cdba7e9"
     },
     "rackspace": {
-      "image": "042395fc-728c-4763-86f9-9b0cacb00701"
+      "image": "3ab30cc6-c503-41d3-8a37-106fda7848a7"
     }
   }
 }

--- a/coopr-server/config/defaults/imagetypes/centos6.json
+++ b/coopr-server/config/defaults/imagetypes/centos6.json
@@ -12,7 +12,7 @@
       "image": "ami-b158c981"
     },
     "google": {
-      "image": "centos-6-v20140718"
+      "image": "centos-6-v20140926"
     },
     "joyent": {
       "image": "bf67d2fc-2ed1-11e4-a6ef-a7df3cdba7e9"

--- a/coopr-server/config/defaults/imagetypes/ubuntu12.json
+++ b/coopr-server/config/defaults/imagetypes/ubuntu12.json
@@ -1,25 +1,25 @@
 {
   "name": "ubuntu12",
-  "description": "Ubuntu 12.04 LTS",
+  "description": "Ubuntu 12.04 LTS (Precise Pangolin)",
   "providermap": {
     "aws-us-east-1": {
-      "image": "ami-4287562a",
+      "image": "ami-ecda6c84",
       "sshuser": "ubuntu"
     },
     "aws-us-west-1": {
-      "image": "ami-33797476",
+      "image": "ami-115c5754",
       "sshuser": "ubuntu"
     },
     "aws-us-west-2": {
-      "image": "ami-23582213",
+      "image": "ami-ad42009d",
       "sshuser": "ubuntu"
     },
     "joyent": {
-      "image": "e28711b3-7f9c-47a7-be7f-ce07e9a99394",
+      "image": "01a24b88-f957-4f9d-9946-fbd21b0612bf",
       "sshuser": "ubuntu"
     },
     "rackspace": {
-      "image": "ffa476b1-9b14-46bd-99a8-862d1d94eb7a"
+      "image": "4a97964e-9787-4af8-a05c-287d81104d49"
     }
   }
 }


### PR DESCRIPTION
Rackspace and Google have updated CentOS images... AWS, Joyent, and Rackspace have updated Ubuntu 12.04 images.
