### PR TITLE
Remove (unconfigurable) disk_config option

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -47,7 +47,6 @@ class FogProviderRackspace < Provider
           name: hostname,
           config_drive: @rackspace_config_drive || false,
           metadata: @rackspace_metadata,
-          disk_config: @rackspace_disk_config || 'AUTO',
           personality: files,
           key_name: @ssh_keypair
         )


### PR DESCRIPTION
This allows use of PVHVM images on Rackspace. We were setting the `disk_config` setting to `AUTO` when it was unconfigured. We had no way to configure this, yet, which made PVHVM images unusable. Removing this option until such time as we can add full support for the option.

More info:
http://www.rackspace.com/knowledge_center/article/choosing-a-virtualization-mode-pv-versus-pvhvm
