### PR TITLE
disabling old ui tests since all new work should be going into the

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
 
     <modules>
         <module>coopr-server</module>
-        <module>coopr-integration-testing</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
new gui and because the tests are long and flaky.
