### PR TITLE
COOPR-496 add links to the cluster template that can point to

### DIFF
--- a/coopr-server/src/main/java/co/cask/coopr/cluster/Cluster.java
+++ b/coopr-server/src/main/java/co/cask/coopr/cluster/Cluster.java
@@ -146,7 +146,7 @@ public final class Cluster extends NamedEntity {
    *
    * @return Set of node ids in the cluster.
    */
-  public Set<String> getNodes() {
+  public Set<String> getNodeIDs() {
     return nodes;
   }
 

--- a/coopr-server/src/main/java/co/cask/coopr/cluster/ClusterDetails.java
+++ b/coopr-server/src/main/java/co/cask/coopr/cluster/ClusterDetails.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package co.cask.coopr.cluster;
+
+import co.cask.coopr.macro.Expander;
+import co.cask.coopr.scheduler.task.ClusterJob;
+import co.cask.coopr.spec.Link;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Full cluster details, including the cluster object itself, all nodes in the cluster, and the progress of the last
+ * job performed on the cluster.
+ */
+public class ClusterDetails {
+  private final Cluster cluster;
+  private final List<Link> links;
+  private final Set<Node> nodes;
+  private final ClusterJobProgress progress;
+  private final String message;
+
+  public ClusterDetails(Cluster cluster, Set<Node> nodes, ClusterJob job) {
+    this.cluster = cluster;
+    this.nodes = ImmutableSet.copyOf(nodes);
+    this.progress = new ClusterJobProgress(job);
+    this.message = job.getStatusMessage();
+    // get links from the cluster template, expanding any macros in them and populating the field
+    ImmutableList.Builder linksBuilder = ImmutableList.builder();
+    for (Link link : cluster.getClusterTemplate().getLinks()) {
+      try {
+        linksBuilder.add(new Link(link.getLabel(), Expander.expand(link.getUrl(), cluster, nodes, null)));
+      } catch (Exception e) {
+        // if we couldn't expand the macro, just use the original string
+        linksBuilder.add(link);
+      }
+    }
+    this.links = linksBuilder.build();
+    for (Node node : this.nodes) {
+      node.populateLinks(cluster, nodes);
+    }
+  }
+
+  /**
+   * Get the cluster.
+   *
+   * @return The cluster
+   */
+  public Cluster getCluster() {
+    return cluster;
+  }
+
+  /**
+   * Get an immutable set of all nodes in the cluster.
+   *
+   * @return Immutable set of all nodes in the cluster
+   */
+  public Set<Node> getNodes() {
+    return nodes;
+  }
+
+  /**
+   * Get the progress of the most recent job performed on the cluster, including any running job.
+   *
+   * @return Progress of the most recent job performed on the cluster, including any running job
+   */
+  public ClusterJobProgress getProgress() {
+    return progress;
+  }
+
+  /**
+   * Get the status message of the most recent job performed on the cluster, including any running job.
+   *
+   * @return Status message of the most recent job performed on the cluster, including any running job
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Get an immutable list of links that should be exposed as specified by the cluster template.
+   *
+   * @return Immutable list of links that should be exposed as specified by the cluster template
+   */
+  public List<Link> getLinks() {
+    return links;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ClusterDetails)) {
+      return false;
+    }
+
+    ClusterDetails that = (ClusterDetails) o;
+    return super.equals(that) &&
+      Objects.equal(nodes, that.nodes) &&
+      Objects.equal(progress, that.progress) &&
+      Objects.equal(message, that.message) &&
+      Objects.equal(links, that.links);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(super.hashCode(), nodes, progress, message, links);
+  }
+}

--- a/coopr-server/src/main/java/co/cask/coopr/cluster/ClusterSummary.java
+++ b/coopr-server/src/main/java/co/cask/coopr/cluster/ClusterSummary.java
@@ -39,7 +39,7 @@ public class ClusterSummary {
     this.provider = provider == null ? null : new NamedEntity(provider.getName());
     ClusterTemplate clusterTemplate = cluster.getClusterTemplate();
     this.clusterTemplate = clusterTemplate == null ? null : new NamedEntity(clusterTemplate.getName());
-    this.numNodes = cluster.getNodes().size();
+    this.numNodes = cluster.getNodeIDs().size();
     this.status = cluster.getStatus();
     this.services = ImmutableSet.copyOf(cluster.getServices());
     this.progress = new ClusterJobProgress(clusterJob);

--- a/coopr-server/src/main/java/co/cask/coopr/cluster/Node.java
+++ b/coopr-server/src/main/java/co/cask/coopr/cluster/Node.java
@@ -15,6 +15,8 @@
  */
 package co.cask.coopr.cluster;
 
+import co.cask.coopr.macro.Expander;
+import co.cask.coopr.spec.Link;
 import co.cask.coopr.spec.service.Service;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -23,6 +25,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -31,14 +35,14 @@ import java.util.Set;
 /**
  * Represents a machine in a cluster.
  */
-public final class Node implements Comparable<Node> {
-  private static final String IPADDRESS_KEY = "ipaddress";
+public class Node implements Comparable<Node> {
   private final String id;
   private final String clusterId;
   private final Set<Service> services;
   private final NodeProperties properties;
   private final List<Action> actions;
   private final JsonObject provisionerResults;
+  private List<Link> links;
 
   /**
    * Node status.
@@ -157,6 +161,27 @@ public final class Node implements Comparable<Node> {
     for (Map.Entry<String, JsonElement> entry : results.entrySet()) {
       this.provisionerResults.add(entry.getKey(), entry.getValue());
     }
+  }
+
+  /**
+   * Get all service links on the node, combine them all, and expand any macros in them. Only useful for display
+   * purposes.
+   */
+  public void populateLinks(Cluster cluster, Set<Node> nodes) {
+    // take links from the services on this node, expand any self macros that may be there, and combine them all
+    ImmutableList.Builder<Link> linksBuilder = ImmutableList.builder();
+    for (Service service : services) {
+      for (Link link : service.getLinks()) {
+        try {
+          // The service link may have macros like %host.self% that should get expanded.
+          linksBuilder.add(new Link(link.getLabel(), Expander.expand(link.getUrl(), cluster, nodes, this)));
+        } catch (Exception e) {
+          // if we couldn't expand the macro, just use the original string
+          linksBuilder.add(link);
+        }
+      }
+    }
+    this.links = linksBuilder.build();
   }
 
   @Override

--- a/coopr-server/src/main/java/co/cask/coopr/cluster/Node.java
+++ b/coopr-server/src/main/java/co/cask/coopr/cluster/Node.java
@@ -144,6 +144,16 @@ public class Node implements Comparable<Node> {
   }
 
   /**
+   * Get an immutable list of service links on the node. Unless {@link #populateLinks(Cluster, java.util.Set)} is
+   * called first, this will return null.
+   *
+   * @return Immutable list of service links on the node.
+   */
+  public List<Link> getLinks() {
+    return links;
+  }
+
+  /**
    * Add a service to the node.
    *
    * @param service Service to add to the node.

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterCodec.java
@@ -17,6 +17,7 @@ package co.cask.coopr.codec.json.current;
 
 import co.cask.coopr.account.Account;
 import co.cask.coopr.cluster.Cluster;
+import co.cask.coopr.codec.json.AbstractCodec;
 import co.cask.coopr.spec.Provider;
 import co.cask.coopr.spec.template.ClusterTemplate;
 import com.google.common.reflect.TypeToken;
@@ -25,14 +26,15 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
 
 import java.lang.reflect.Type;
 import java.util.Set;
 
 /**
- * Codec for serializing/deserializing a {@link Cluster}. Used for backwards compatibility.
+ * Codec for serializing/deserializing a {@link Cluster}. Used to make sure required fields are present.
  */
-public class ClusterCodec implements JsonDeserializer<Cluster> {
+public class ClusterCodec extends AbstractCodec<Cluster> {
 
   @Override
   public Cluster deserialize(JsonElement json, Type type, JsonDeserializationContext context)
@@ -54,5 +56,31 @@ public class ClusterCodec implements JsonDeserializer<Cluster> {
       .setStatus(context.<Cluster.Status>deserialize(jsonObj.get("status"), Cluster.Status.class))
       .setConfig(context.<JsonObject>deserialize(jsonObj.get("config"), JsonObject.class))
       .build();
+  }
+
+  @Override
+  public JsonElement serialize(Cluster src, Type typeOfSrc, JsonSerializationContext context) {
+    return serializeCluster(src, context);
+  }
+
+  public static JsonObject serializeCluster(Cluster cluster, JsonSerializationContext context) {
+
+    JsonObject jsonObj = new JsonObject();
+
+    jsonObj.add("id", context.serialize(cluster.getId()));
+    jsonObj.add("name", context.serialize(cluster.getName()));
+    jsonObj.add("description", context.serialize(cluster.getDescription()));
+    jsonObj.add("account", context.serialize(cluster.getAccount()));
+    jsonObj.add("createTime", context.serialize(cluster.getCreateTime()));
+    jsonObj.add("expireTime", context.serialize(cluster.getExpireTime()));
+    jsonObj.add("provider", context.serialize(cluster.getProvider()));
+    jsonObj.add("clusterTemplate", context.serialize(cluster.getClusterTemplate()));
+    jsonObj.add("nodes", context.serialize(cluster.getNodeIDs()));
+    jsonObj.add("services", context.serialize(cluster.getServices()));
+    jsonObj.add("latestJobId", context.serialize(cluster.getLatestJobId()));
+    jsonObj.add("status", context.serialize(cluster.getStatus()));
+    jsonObj.add("config", context.serialize(cluster.getConfig()));
+
+    return jsonObj;
   }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterDetailsCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterDetailsCodec.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2012-2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package co.cask.coopr.codec.json.current;
+
+import co.cask.coopr.cluster.ClusterDetails;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Codec for serializing {@link co.cask.coopr.cluster.ClusterDetails}.
+ */
+public class ClusterDetailsCodec implements JsonSerializer<ClusterDetails> {
+
+  @Override
+  public JsonElement serialize(ClusterDetails src, Type typeOfSrc, JsonSerializationContext context) {
+    // flattening the cluster object and adding the rest of the cluster details fields on top of the cluster's
+    // fields. This weirdness is to preserve the cluster rest api, which was doing some weird combining of a cluster
+    // and its nodes and its latest job.
+    JsonObject jsonObj = ClusterCodec.serializeCluster(src.getCluster(), context);
+
+    // node ids get overwritten by the full node objects
+    jsonObj.add("nodes", context.serialize(src.getNodes()));
+    jsonObj.add("links", context.serialize(src.getLinks()));
+    jsonObj.add("progress", context.serialize(src.getProgress()));
+    jsonObj.add("message", context.serialize(src.getMessage()));
+
+    return jsonObj;
+  }
+}

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterTemplateCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterTemplateCodec.java
@@ -16,6 +16,7 @@
 package co.cask.coopr.codec.json.current;
 
 import co.cask.coopr.codec.json.AbstractCodec;
+import co.cask.coopr.spec.Link;
 import co.cask.coopr.spec.template.Administration;
 import co.cask.coopr.spec.template.ClusterDefaults;
 import co.cask.coopr.spec.template.ClusterTemplate;
@@ -26,8 +27,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
+import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.util.Set;
 
 /**
  * Codec for serializing/deserializing a {@link ClusterTemplate}.
@@ -43,8 +46,9 @@ public class ClusterTemplateCodec extends AbstractCodec<ClusterTemplate> {
     jsonObj.add("description", context.serialize(clusterTemplate.getDescription()));
     jsonObj.add("defaults", context.serialize(clusterTemplate.getClusterDefaults()));
     jsonObj.add("compatibility", context.serialize(clusterTemplate.getCompatibilities()));
-    jsonObj.add("constraints", context.serialize(clusterTemplate.getConstraints(), Constraints.class));
-    jsonObj.add("administration", context.serialize(clusterTemplate.getAdministration(), Administration.class));
+    jsonObj.add("constraints", context.serialize(clusterTemplate.getConstraints()));
+    jsonObj.add("administration", context.serialize(clusterTemplate.getAdministration()));
+    jsonObj.add("links", context.serialize(clusterTemplate.getLinks()));
 
     return jsonObj;
   }
@@ -62,6 +66,7 @@ public class ClusterTemplateCodec extends AbstractCodec<ClusterTemplate> {
       .setCompatibilities(context.<Compatibilities>deserialize(jsonObj.get("compatibility"), Compatibilities.class))
       .setConstraints(context.<Constraints>deserialize(jsonObj.get("constraints"), Constraints.class))
       .setAdministration(context.<Administration>deserialize(jsonObj.get("administration"), Administration.class))
+      .setLinks(context.<Set<Link>>deserialize(jsonObj.get("links"), new TypeToken<Set<Link>>() {}.getType()))
       .build();
   }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterTemplateCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ClusterTemplateCodec.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
-import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.Set;
@@ -36,6 +35,7 @@ import java.util.Set;
  * Codec for serializing/deserializing a {@link ClusterTemplate}.
  */
 public class ClusterTemplateCodec extends AbstractCodec<ClusterTemplate> {
+  private static final Type LINKS_TYPE = new com.google.common.reflect.TypeToken<Set<Link>>() {}.getType();
 
   @Override
   public JsonElement serialize(ClusterTemplate clusterTemplate, Type type, JsonSerializationContext context) {
@@ -66,7 +66,7 @@ public class ClusterTemplateCodec extends AbstractCodec<ClusterTemplate> {
       .setCompatibilities(context.<Compatibilities>deserialize(jsonObj.get("compatibility"), Compatibilities.class))
       .setConstraints(context.<Constraints>deserialize(jsonObj.get("constraints"), Constraints.class))
       .setAdministration(context.<Administration>deserialize(jsonObj.get("administration"), Administration.class))
-      .setLinks(context.<Set<Link>>deserialize(jsonObj.get("links"), new TypeToken<Set<Link>>() {}.getType()))
+      .setLinks(context.<Set<Link>>deserialize(jsonObj.get("links"), LINKS_TYPE))
       .build();
   }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ServiceCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ServiceCodec.java
@@ -37,6 +37,8 @@ import java.util.Set;
  * Codec for serializing/deserializing a {@link Service}.
  */
 public class ServiceCodec extends AbstractCodec<Service> {
+  private static final Type ACTIONS_TYPE = new TypeToken<Map<ProvisionerAction, ServiceAction>>() {}.getType();
+  private static final Type LINKS_TYPE = new TypeToken<Set<Link>>() {}.getType();
 
   @Override
   public JsonElement serialize(Service service, Type type, JsonSerializationContext context) {
@@ -67,10 +69,9 @@ public class ServiceCodec extends AbstractCodec<Service> {
     JsonObject provisioner = context.deserialize(jsonObj.get("provisioner"), JsonObject.class);
     Map<ProvisionerAction, ServiceAction> actions = Collections.emptyMap();
     if (provisioner != null) {
-      actions = context.deserialize(provisioner.get("actions"),
-                                    new TypeToken<Map<ProvisionerAction, ServiceAction>>() {}.getType());
+      actions = context.deserialize(provisioner.get("actions"), ACTIONS_TYPE);
     }
-    Set<Link> links = context.deserialize(jsonObj.get("links"), new TypeToken<Set<Link>>() {}.getType());
+    Set<Link> links = context.deserialize(jsonObj.get("links"), LINKS_TYPE);
 
     return Service.builder()
       .setName(name)

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ServiceCodec.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/current/ServiceCodec.java
@@ -16,6 +16,7 @@
 package co.cask.coopr.codec.json.current;
 
 import co.cask.coopr.codec.json.AbstractCodec;
+import co.cask.coopr.spec.Link;
 import co.cask.coopr.spec.ProvisionerAction;
 import co.cask.coopr.spec.service.Service;
 import co.cask.coopr.spec.service.ServiceAction;
@@ -30,6 +31,7 @@ import com.google.gson.JsonSerializationContext;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Codec for serializing/deserializing a {@link Service}.
@@ -47,6 +49,7 @@ public class ServiceCodec extends AbstractCodec<Service> {
     JsonObject provisioner = new JsonObject();
     provisioner.add("actions", context.serialize(service.getProvisionerActions()));
     jsonObj.add("provisioner", provisioner);
+    jsonObj.add("links", context.serialize(service.getLinks()));
 
     return jsonObj;
   }
@@ -65,8 +68,9 @@ public class ServiceCodec extends AbstractCodec<Service> {
     Map<ProvisionerAction, ServiceAction> actions = Collections.emptyMap();
     if (provisioner != null) {
       actions = context.deserialize(provisioner.get("actions"),
-                                   new TypeToken<Map<ProvisionerAction, ServiceAction>>(){}.getType());
+                                    new TypeToken<Map<ProvisionerAction, ServiceAction>>() {}.getType());
     }
+    Set<Link> links = context.deserialize(jsonObj.get("links"), new TypeToken<Set<Link>>() {}.getType());
 
     return Service.builder()
       .setName(name)
@@ -74,6 +78,7 @@ public class ServiceCodec extends AbstractCodec<Service> {
       .setDescription(description)
       .setDependencies(dependencies)
       .setProvisionerActions(actions)
+      .setLinks(links)
       .build();
   }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/codec/json/guice/CodecModules.java
+++ b/coopr-server/src/main/java/co/cask/coopr/codec/json/guice/CodecModules.java
@@ -16,6 +16,7 @@
 package co.cask.coopr.codec.json.guice;
 
 import co.cask.coopr.cluster.Cluster;
+import co.cask.coopr.cluster.ClusterDetails;
 import co.cask.coopr.cluster.Node;
 import co.cask.coopr.codec.json.LowercaseEnumTypeAdapterFactory;
 import co.cask.coopr.codec.json.current.AddServicesRequestCodec;
@@ -25,6 +26,7 @@ import co.cask.coopr.codec.json.current.ClusterCodec;
 import co.cask.coopr.codec.json.current.ClusterConfigureRequestCodec;
 import co.cask.coopr.codec.json.current.ClusterCreateRequestCodec;
 import co.cask.coopr.codec.json.current.ClusterDefaultsCodec;
+import co.cask.coopr.codec.json.current.ClusterDetailsCodec;
 import co.cask.coopr.codec.json.current.ClusterOperationRequestCodec;
 import co.cask.coopr.codec.json.current.ClusterTemplateCodec;
 import co.cask.coopr.codec.json.current.ConstraintsCodec;
@@ -122,6 +124,7 @@ public class CodecModules {
       .registerTypeAdapter(ClusterConfigureRequest.class, new ClusterConfigureRequestCodec())
       .registerTypeAdapter(ClusterCreateRequest.class, new ClusterCreateRequestCodec())
       .registerTypeAdapter(ClusterDefaults.class, new ClusterDefaultsCodec())
+      .registerTypeAdapter(ClusterDetails.class, new ClusterDetailsCodec())
       .registerTypeAdapter(ClusterOperationRequest.class, new ClusterOperationRequestCodec())
       .registerTypeAdapter(ClusterTemplate.class, new ClusterTemplateCodec())
       .registerTypeAdapter(Constraints.class, new ConstraintsCodec())

--- a/coopr-server/src/main/java/co/cask/coopr/provisioner/TenantProvisionerService.java
+++ b/coopr-server/src/main/java/co/cask/coopr/provisioner/TenantProvisionerService.java
@@ -203,7 +203,7 @@ public class TenantProvisionerService {
 
     int numNodes = additionalNodes;
     for (Cluster cluster : nonTerminatedClusters) {
-      numNodes += cluster.getNodes().size();
+      numNodes += cluster.getNodeIDs().size();
     }
     if (numNodes > tenant.getSpecification().getMaxNodes()) {
       return false;

--- a/coopr-server/src/main/java/co/cask/coopr/spec/Link.java
+++ b/coopr-server/src/main/java/co/cask/coopr/spec/Link.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package co.cask.coopr.spec;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+/**
+ * Specification to expose a link at the cluster or node level.
+ */
+public class Link {
+  private final String label;
+  private final String url;
+
+  public Link(String label, String url) {
+    Preconditions.checkArgument(url != null && !url.isEmpty(), "url must be specified");
+    this.label = label;
+    this.url = url;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Link)) {
+      return false;
+    }
+
+    Link that = (Link) o;
+
+    return Objects.equal(label, that.label) &&
+      Objects.equal(url, that.url);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(label, url);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("label", label)
+      .add("url", url)
+      .toString();
+  }
+}

--- a/coopr-server/src/main/java/co/cask/coopr/spec/service/Service.java
+++ b/coopr-server/src/main/java/co/cask/coopr/spec/service/Service.java
@@ -15,13 +15,15 @@
  */
 package co.cask.coopr.spec.service;
 
+import co.cask.coopr.spec.Link;
 import co.cask.coopr.spec.NamedIconEntity;
 import co.cask.coopr.spec.ProvisionerAction;
 import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A service defines a set of services it is dependent on, as well as a mapping of
@@ -32,13 +34,15 @@ public final class Service extends NamedIconEntity {
   private final String description;
   private final ServiceDependencies dependencies;
   private final Map<ProvisionerAction, ServiceAction> provisionerActions;
+  private final Set<Link> links;
 
   private Service(String name, String logolink, String description, ServiceDependencies dependencies,
-                  Map<ProvisionerAction, ServiceAction> provisionerActions) {
+                  Map<ProvisionerAction, ServiceAction> provisionerActions, Set<Link> links) {
     super(name, logolink);
     this.description = description;
     this.dependencies = dependencies;
     this.provisionerActions = provisionerActions;
+    this.links = links;
   }
 
   /**
@@ -69,6 +73,15 @@ public final class Service extends NamedIconEntity {
   }
 
   /**
+   * Get an immutable set of links the service wants to expose.
+   *
+   * @return Immutable set of links the service wants to expose.
+   */
+  public Set<Link> getLinks() {
+    return links;
+  }
+
+  /**
    * Get a builder for creating a service.
    *
    * @return Builder for creating a service.
@@ -86,6 +99,7 @@ public final class Service extends NamedIconEntity {
     private String description = "";
     private ServiceDependencies dependencies = ServiceDependencies.EMPTY_SERVICE_DEPENDENCIES;
     private Map<ProvisionerAction, ServiceAction> provisionerActions = ImmutableMap.of();
+    private Set<Link> links = ImmutableSet.of();
 
     public Builder setName(String name) {
       this.name = name;
@@ -112,8 +126,13 @@ public final class Service extends NamedIconEntity {
       return this;
     }
 
+    public Builder setLinks(Set<Link> links) {
+      this.links = links == null ? ImmutableSet.<Link>of() : ImmutableSet.copyOf(links);
+      return this;
+    }
+
     public Service build() {
-      return new Service(name, icon, description, dependencies, provisionerActions);
+      return new Service(name, icon, description, dependencies, provisionerActions, links);
     }
   }
 
@@ -126,12 +145,13 @@ public final class Service extends NamedIconEntity {
     return super.equals(other) &&
       Objects.equal(description, other.description) &&
       Objects.equal(dependencies, other.dependencies) &&
-      Objects.equal(provisionerActions, other.provisionerActions);
+      Objects.equal(provisionerActions, other.provisionerActions) &&
+      Objects.equal(links, other.links);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(super.hashCode(), description, icon, dependencies, provisionerActions);
+    return Objects.hashCode(super.hashCode(), description, icon, dependencies, provisionerActions, links);
   }
 
   @Override
@@ -140,6 +160,7 @@ public final class Service extends NamedIconEntity {
       .add("description", description)
       .add("dependencies", dependencies)
       .add("provisionerActions", provisionerActions)
+      .add("links", links)
       .toString();
   }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/spec/service/ServiceDependencies.java
+++ b/coopr-server/src/main/java/co/cask/coopr/spec/service/ServiceDependencies.java
@@ -174,4 +174,14 @@ public class ServiceDependencies {
   public int hashCode() {
     return Objects.hashCode(provides, conflicts, install, runtime);
   }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("provides", provides)
+      .add("conflicts", conflicts)
+      .add("install", install)
+      .add("runtime", runtime)
+      .toString();
+  }
 }

--- a/coopr-server/src/main/java/co/cask/coopr/spec/template/ClusterTemplate.java
+++ b/coopr-server/src/main/java/co/cask/coopr/spec/template/ClusterTemplate.java
@@ -15,9 +15,13 @@
  */
 package co.cask.coopr.spec.template;
 
+import co.cask.coopr.spec.Link;
 import co.cask.coopr.spec.NamedIconEntity;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 /**
  * A cluster template defines different types of clusters that will be available for users to create.  Templates
@@ -31,9 +35,11 @@ public final class ClusterTemplate extends NamedIconEntity {
   private final Constraints constraints;
   private final Compatibilities compatibilities;
   private final Administration administration;
+  private final Set<Link> links;
 
   private ClusterTemplate(String name, String icon, String description, ClusterDefaults clusterDefaults,
-                          Compatibilities compatibilities, Constraints constraints, Administration administration) {
+                          Compatibilities compatibilities, Constraints constraints, Administration administration,
+                          Set<Link> links) {
     super(name, icon);
     Preconditions.checkArgument(clusterDefaults != null, "cluster defaults must be specified");
     this.clusterDefaults = clusterDefaults;
@@ -41,6 +47,7 @@ public final class ClusterTemplate extends NamedIconEntity {
     this.constraints = constraints;
     this.compatibilities = compatibilities;
     this.administration = administration;
+    this.links = links;
   }
 
   /**
@@ -89,9 +96,18 @@ public final class ClusterTemplate extends NamedIconEntity {
   }
 
   /**
-   * Return a builder for creating a cluster template.
+   * Get immutable set of cluster links to services on the cluster.
    *
-   * @return Builder for creating a cluster template.
+   * @return Immutable set of cluster links to services on the cluster
+   */
+  public Set<Link> getLinks() {
+    return links;
+  }
+
+  /**
+   * Get a builder for creating cluster templates.
+   *
+   * @return Builder for creating cluster templates.
    */
   public static Builder builder() {
     return new Builder();
@@ -103,11 +119,12 @@ public final class ClusterTemplate extends NamedIconEntity {
   public static class Builder {
     private String name;
     private String icon;
-    private String description;
+    private String description = "";
     private ClusterDefaults clusterDefaults;
     private Constraints constraints = Constraints.EMPTY_CONSTRAINTS;
     private Compatibilities compatibilities = Compatibilities.EMPTY_COMPATIBILITIES;
     private Administration administration = Administration.EMPTY_ADMINISTRATION;
+    private Set<Link> links = ImmutableSet.of();
 
     public Builder setName(String name) {
       this.name = name;
@@ -130,23 +147,28 @@ public final class ClusterTemplate extends NamedIconEntity {
     }
 
     public Builder setConstraints(Constraints constraints) {
-      this.constraints = constraints;
+      this.constraints = constraints == null ? Constraints.EMPTY_CONSTRAINTS : constraints;
       return this;
     }
 
     public Builder setCompatibilities(Compatibilities compatibilities) {
-      this.compatibilities = compatibilities;
+      this.compatibilities = compatibilities == null ? Compatibilities.EMPTY_COMPATIBILITIES : compatibilities;
       return this;
     }
 
     public Builder setAdministration(Administration administration) {
-      this.administration = administration;
+      this.administration = administration == null ? Administration.EMPTY_ADMINISTRATION : administration;
+      return this;
+    }
+
+    public Builder setLinks(Set<Link> links) {
+      this.links = links == null ? ImmutableSet.<Link>of() : ImmutableSet.copyOf(links);
       return this;
     }
 
     public ClusterTemplate build() {
       return new ClusterTemplate(name, icon, description, clusterDefaults,
-                                 compatibilities, constraints, administration);
+                                 compatibilities, constraints, administration, links);
     }
   }
 
@@ -160,12 +182,13 @@ public final class ClusterTemplate extends NamedIconEntity {
       Objects.equal(description, other.description) &&
       Objects.equal(compatibilities, other.compatibilities) &&
       Objects.equal(constraints, other.constraints) &&
-      Objects.equal(administration, other.administration);
+      Objects.equal(administration, other.administration) &&
+      Objects.equal(links, other.links);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(super.hashCode(), description, compatibilities, constraints, administration);
+    return Objects.hashCode(super.hashCode(), description, compatibilities, constraints, administration, links);
   }
 
   @Override
@@ -176,6 +199,7 @@ public final class ClusterTemplate extends NamedIconEntity {
       .add("constraints", constraints)
       .add("compatibilities", compatibilities)
       .add("administration", administration)
+      .add("links", links)
       .toString();
   }
 }

--- a/coopr-server/src/test/java/co/cask/coopr/layout/change/AddServicesChangeTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/layout/change/AddServicesChangeTest.java
@@ -214,7 +214,7 @@ public class AddServicesChangeTest extends BaseSolverTest {
       .setCreateTime(cluster.getCreateTime())
       .setProvider(cluster.getProvider())
       .setClusterTemplate(cluster.getClusterTemplate())
-      .setNodes(cluster.getNodes())
+      .setNodes(cluster.getNodeIDs())
       .setServices(services)
       .build();
   }

--- a/coopr-server/src/test/java/co/cask/coopr/scheduler/SolverSchedulerTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/scheduler/SolverSchedulerTest.java
@@ -100,7 +100,7 @@ public class SolverSchedulerTest extends BaseTest {
     Assert.assertEquals("my cluster", solvedCluster.getDescription());
     // check the node counts are as expected
     Multiset<Set<String>> serviceSetCounts = HashMultiset.create();
-    for (String nodeId : solvedCluster.getNodes()) {
+    for (String nodeId : solvedCluster.getNodeIDs()) {
       Node node = clusterStore.getNode(nodeId);
       Set<String> serviceNames = Sets.newHashSet(Iterables.transform(node.getServices(),
                                                                      new Function<Service, String>() {


### PR DESCRIPTION
various useful service UIs. Services and cluster templates have
a links field that consists of an array of links, where a link
is a label and a url. The url can contain macros. When a cluster
is fetched from the rest api, links in the cluster template are
expanded and placed at the top level of the returned object.
In addition, for every node in the cluster, the links for all
services on the node are taken, expanded, and combined into a list
of links for the node.
