### PR TITLE
Write out SSH file if ssh_keyfile

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/.rubocop.yml
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/.rubocop.yml
@@ -1,1 +1,3 @@
 inherit_from: .rubocop_todo.yml
+AsciiComments:
+  Enabled: false

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -29,6 +29,12 @@ class ChefSoloAutomator < Automator
   @@remote_cache_dir = '/var/cache/coopr'
   @@remote_chef_dir = '/var/chef'
 
+  # plugin defined resources
+  @ssh_key_dir = 'ssh_keys'
+  class << self
+    attr_accessor :ssh_key_dir
+  end
+
   # create local tarballs of the cookbooks, roles, data_bags, etc to be scp'd to remote machine
   def generate_chef_primitive_tar(chef_primitive)
 
@@ -52,6 +58,15 @@ class ChefSoloAutomator < Automator
     # rubocop:enable GuardClause
   end
 
+  def write_ssh_file
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    unless @ssh_keyfile.nil?
+      @task['config']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @task['taskId'])
+      log.debug "Writing out @ssh_keyfile to #{@task['config']['ssh-auth']['identityfile']}"
+      decode_string_to_file(@ssh_keyfile, @task['config']['ssh-auth']['identityfile'])
+    end
+  end
+
   def set_credentials(sshauth)
     @credentials = Hash.new
     @credentials[:paranoid] = false
@@ -64,9 +79,9 @@ class ChefSoloAutomator < Automator
     end
   end
 
-  def decode_string_to_file(string, outfile)
+  def decode_string_to_file(string, outfile, mode = 0600)
     FileUtils.mkdir_p(File.dirname(outfile))
-    File.open(outfile, 'wb') { |f| f.write(Base64.decode64(string)) }
+    File.open(outfile, 'wb', mode) { |f| f.write(Base64.decode64(string)) }
   end
 
   # generate the chef run json_attributes from the task metadata
@@ -123,16 +138,10 @@ class ChefSoloAutomator < Automator
     hostname = inputmap['hostname']
     ipaddress = inputmap['ipaddress']
 
-    # Write credentials
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    unless @ssh_keyfile.nil? || @task['config']['ssh-auth']['identityfile'].nil?
-      log.debug "Writing out @ssh_keyfile to #{@task['config']['ssh-auth']['identityfile']}"
-      decode_string_to_file(@ssh_keyfile, @task['config']['ssh-auth']['identityfile'])
-    end
-
     # do we need sudo bash?
     sudo = 'sudo' unless sshauth['user'] == 'root'
 
+    write_ssh_file
     set_credentials(sshauth)
 
     @@chef_primitives.each do |chef_primitive|
@@ -250,6 +259,7 @@ class ChefSoloAutomator < Automator
     # do we need sudo bash?
     sudo = 'sudo' unless sshauth['user'] == 'root'
 
+    write_ssh_file
     set_credentials(sshauth)
 
     begin

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -232,7 +232,7 @@ class ChefSoloAutomator < Automator
     log.debug "ChefSoloAutomator bootstrap completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if File.exist?(@ssh_file)
+    File.delete(@ssh_file) if File.exist?(@ssh_file) && @ssh_file
   end
 
   def runchef(inputmap)
@@ -293,7 +293,7 @@ class ChefSoloAutomator < Automator
     log.debug "Chef-solo run completed successfully for task #{@task['taskId']}: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if File.exist?(@ssh_file)
+    File.delete(@ssh_file) if File.exist?(@ssh_file) && @ssh_file
   end
 
   def install(inputmap)

--- a/coopr-provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/coopr-provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -86,9 +86,9 @@ class ShellAutomator < Automator
     end
   end
 
-  def decode_string_to_file(string, outfile)
+  def decode_string_to_file(string, outfile, mode = 0600)
     FileUtils.mkdir_p(File.dirname(outfile))
-    File.open(outfile, 'wb') { |f| f.write(Base64.decode64(string)) }
+    File.open(outfile, 'wb', mode) { |f| f.write(Base64.decode64(string)) }
   end
 
   def runshell(inputmap)


### PR DESCRIPTION
Writes out task-specific SSH files when `@task['config']['provider']['provisioner']['ssh_keyfile']` is set and clean up after ourselves.
