### PR TITLE
COOPR-324 make sure all system generated hostnames have labels

### DIFF
--- a/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
+++ b/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
  * Utility for strings.
  */
 public class StringUtils {
-  //
   private static final Pattern labelPattern = Pattern.compile("^[a-zA-Z0-9\\-]{0,62}[a-zA-Z0-9]$");
 
   /**

--- a/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
+++ b/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
@@ -15,16 +15,43 @@
  */
 package co.cask.coopr.common.utils;
 
+import com.google.common.base.Splitter;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 
 /**
  * Utility for strings.
  */
 public class StringUtils {
+  //
+  private static final Pattern labelPattern = Pattern.compile("^[a-zA-Z0-9\\-]{0,62}[a-zA-Z0-9]$");
+
+  /**
+   * Check if the given DNS suffix is valid by checking that each label is at least 1 and at most 63 characters
+   * in length. Also check that each label has only characters, numbers, or '-', and that the entire suffix is
+   * at most 255 - 63 - 1 characters, since it will be appended to a single label later on to create a hostname.
+   * Also need to check that no label ends in a dash.
+   *
+   * @param suffix the suffix to check
+   * @return true is it is valid and false if it is not
+   */
+  public static boolean isValidDNSSuffix(String suffix) throws IllegalArgumentException {
+    if (suffix.length() > 191) {
+      return false;
+    }
+    for (String label : Splitter.on('.').split(suffix)) {
+      if (!labelPattern.matcher(label).matches()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Returns an arraylist of strings.
    * @param str the comma seperated string values

--- a/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
+++ b/coopr-server/src/main/java/co/cask/coopr/common/utils/StringUtils.java
@@ -31,6 +31,22 @@ public class StringUtils {
   private static final Pattern labelPattern = Pattern.compile("^[a-zA-Z0-9\\-]{0,62}[a-zA-Z0-9]$");
 
   /**
+   * Strip all leading digits from a string. For example, "1234abc" becomes "abc". If the string is comprised
+   * entirely of digits, the empty string is returned.
+   *
+   * @param str string to strip
+   * @return string with leading digits stripped
+   */
+  public static String stripLeadingDigits(String str) {
+    for (int i = 0; i < str.length(); i++) {
+      if (!Character.isDigit(str.charAt(i))) {
+        return str.substring(i);
+      }
+    }
+    return "";
+  }
+
+  /**
    * Check if the given DNS suffix is valid by checking that each label is at least 1 and at most 63 characters
    * in length. Also check that each label has only characters, numbers, or '-', and that the entire suffix is
    * at most 255 - 63 - 1 characters, since it will be appended to a single label later on to create a hostname.

--- a/coopr-server/src/main/java/co/cask/coopr/http/request/ClusterCreateRequest.java
+++ b/coopr-server/src/main/java/co/cask/coopr/http/request/ClusterCreateRequest.java
@@ -15,6 +15,7 @@
  */
 package co.cask.coopr.http.request;
 
+import co.cask.coopr.common.utils.StringUtils;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
@@ -39,7 +40,7 @@ public class ClusterCreateRequest extends ClusterOperationRequest {
   private final JsonObject config;
 
   private ClusterCreateRequest(String name, String description, String clusterTemplate,
-                               int numMachines, String provider, Map<String, Object> providerFields,
+                               Integer numMachines, String provider, Map<String, Object> providerFields,
                                Set<String> services, String hardwareType, String imageType, Long initialLeaseDuration,
                                String dnsSuffix, JsonObject config) {
     super(providerFields);
@@ -47,7 +48,9 @@ public class ClusterCreateRequest extends ClusterOperationRequest {
     Preconditions.checkArgument(name != null && !name.isEmpty(), "cluster name must be specified");
     Preconditions.checkArgument(clusterTemplate != null && !clusterTemplate.isEmpty(),
                                 "cluster template must be specified");
-    Preconditions.checkArgument(numMachines > 0, "cluster size must be greater than 0");
+    Preconditions.checkArgument(numMachines != null && numMachines > 0, "cluster size must be greater than 0");
+    Preconditions.checkArgument(dnsSuffix == null || StringUtils.isValidDNSSuffix(dnsSuffix),
+                                dnsSuffix + " is an invalid DNS suffix.");
     this.name = name;
     this.description = description == null ? "" : description;
     this.clusterTemplate = clusterTemplate;

--- a/coopr-server/src/main/java/co/cask/coopr/scheduler/task/NodeService.java
+++ b/coopr-server/src/main/java/co/cask/coopr/scheduler/task/NodeService.java
@@ -18,6 +18,7 @@ package co.cask.coopr.scheduler.task;
 import co.cask.coopr.cluster.Node;
 import co.cask.coopr.common.conf.Configuration;
 import co.cask.coopr.common.conf.Constants;
+import co.cask.coopr.common.utils.StringUtils;
 import co.cask.coopr.store.cluster.ClusterStore;
 import co.cask.coopr.store.cluster.ClusterStoreService;
 import com.google.inject.Inject;
@@ -143,8 +144,10 @@ public class NodeService {
     // to get the first label of the hostname.
     // ex: name53-1000
     String labelSuffix = clusterIdNum + "-" + nodeNum;
+    // it is technically valid to have a hostname that has digits in the front, but it used to not be valid
+    // stripping leading digits to play nice with older code which may check for leading digits.
+    String labelPrefix = StringUtils.stripLeadingDigits(clusterName);
     // the label must be from 1 to 63 (inclusive) characters in length. If the name is too long, chop off the end
-    String labelPrefix = clusterName;
     if (labelPrefix.length() + labelSuffix.length() > 63) {
       labelPrefix = labelPrefix.substring(0, 63 - labelSuffix.length());
     }

--- a/coopr-server/src/main/java/co/cask/coopr/spec/template/ClusterDefaults.java
+++ b/coopr-server/src/main/java/co/cask/coopr/spec/template/ClusterDefaults.java
@@ -16,6 +16,7 @@
 
 package co.cask.coopr.spec.template;
 
+import co.cask.coopr.common.utils.StringUtils;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -39,6 +40,8 @@ public class ClusterDefaults {
                           String imagetype, String dnsSuffix, JsonObject config) {
     Preconditions.checkArgument(services != null && !services.isEmpty(), "default services must be specified");
     Preconditions.checkArgument(provider != null, "default provider must be specified");
+    Preconditions.checkArgument(dnsSuffix == null || StringUtils.isValidDNSSuffix(dnsSuffix),
+                                dnsSuffix + " is an invalid DNS suffix.");
     this.services = services;
     this.provider = provider;
     this.hardwaretype = hardwaretype;

--- a/coopr-server/src/test/java/co/cask/coopr/common/utils/StringUtilsTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/common/utils/StringUtilsTest.java
@@ -34,4 +34,10 @@ public class StringUtilsTest {
     Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa)y.net"));
     Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa/y.net"));
   }
+
+  @Test
+  public void testStripLeadingDigits() {
+    Assert.assertEquals("", StringUtils.stripLeadingDigits("1234567890"));
+    Assert.assertEquals("abc", StringUtils.stripLeadingDigits("1234567890abc"));
+  }
 }

--- a/coopr-server/src/test/java/co/cask/coopr/common/utils/StringUtilsTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/common/utils/StringUtilsTest.java
@@ -1,0 +1,37 @@
+package co.cask.coopr.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class StringUtilsTest {
+
+  @Test
+  public void testDNSSuffixLengthValidation() {
+    // 26 + 26 + 10 + 1 = 63 characters.
+    String validLabel = "abcdefghijklmnopqrstuvwxyz0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    Assert.assertTrue(StringUtils.isValidDNSSuffix(validLabel + "." + validLabel + "." + validLabel));
+
+    // test overall length check
+    Assert.assertFalse(StringUtils.isValidDNSSuffix(validLabel + "." + validLabel + "." + validLabel + "." + "asdf"));
+    // test label length
+    Assert.assertFalse(StringUtils.isValidDNSSuffix(validLabel + "." + validLabel + "0"));
+    // test dash at end of label
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.123fasd-.net"));
+    // test some invalid chars
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa_y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa*y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa?y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa&y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa^y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa%y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa#y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa@y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa!y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa(y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa)y.net"));
+    Assert.assertFalse(StringUtils.isValidDNSSuffix("dev.compa/y.net"));
+  }
+}

--- a/coopr-server/src/test/java/co/cask/coopr/scheduler/task/NodeServiceTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/scheduler/task/NodeServiceTest.java
@@ -36,20 +36,20 @@ public class NodeServiceTest extends ServiceTestBase {
   public void testCreateHostname() {
     String clusterId = "00000001";
     Assert.assertEquals("i-am-a-cluster1-1002.local",
-                        NodeService.createHostname("i.am-a_cluster", clusterId, 1002, null));
+                        NodeService.createHostname("i.am-a_clusTer", clusterId, 1002, null));
   }
 
   @Test
   public void testLongHostname() {
     String clusterId = "00000123";
     String domain = "dev.company.com";
-    String expectedSuffix = "123-1002." + domain;
+    String labelSuffix = "123-1002";
     StringBuilder longName = new StringBuilder();
-    for (int i = 0; i < 255 - expectedSuffix.length(); i++) {
+    for (int i = 0; i < 63 - labelSuffix.length(); i++) {
       longName.append("a");
     }
     String bigName = longName.toString();
-    Assert.assertEquals(bigName + expectedSuffix,
+    Assert.assertEquals(bigName + labelSuffix + "." + domain,
                         NodeService.createHostname(bigName + "bcde", clusterId, 1002, domain));
 
   }

--- a/coopr-server/src/test/java/co/cask/coopr/scheduler/task/NodeServiceTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/scheduler/task/NodeServiceTest.java
@@ -36,7 +36,7 @@ public class NodeServiceTest extends ServiceTestBase {
   public void testCreateHostname() {
     String clusterId = "00000001";
     Assert.assertEquals("i-am-a-cluster1-1002.local",
-                        NodeService.createHostname("i.am-a_clusTer", clusterId, 1002, null));
+                        NodeService.createHostname("123i.am-a_clusTer", clusterId, 1002, null));
   }
 
   @Test


### PR DESCRIPTION
that do not exceed 63 characters.
Also lowercasing the entire hostname for consistency since they
should be case insensitive anyway.
