### PR TITLE
only check for disk vdb for now since thats all we operate on

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -110,7 +110,7 @@ class FogProviderJoyent < Provider
           # confirm it is not already mounted
           #   ubuntu: we remount from /mnt to /data
           #   centos: vdb1 already mounted at /data
-          ssh_exec!(ssh, 'if grep "vdb.* /data " /proc/mounts ; then /bin/false ; fi', 'Checking if /dev/vdb mounted already')
+          ssh_exec!(ssh, 'if grep "vdb /data " /proc/mounts ; then /bin/false ; fi', 'Checking if /dev/vdb mounted already')
         rescue
           vdb = false
         end


### PR DESCRIPTION
short-term fix for joyent mounting issue. only check for /vdb for now, since thats the only disk we attempt to remount. longer term we should individually operate on vdb and then vdb1
