### PR TITLE
COOPR-516 Move a cluster to the 'terminated' state instead of

### DIFF
--- a/coopr-server/src/main/java/co/cask/coopr/scheduler/JobScheduler.java
+++ b/coopr-server/src/main/java/co/cask/coopr/scheduler/JobScheduler.java
@@ -33,6 +33,7 @@ import co.cask.coopr.scheduler.task.SchedulableTask;
 import co.cask.coopr.scheduler.task.TaskConfig;
 import co.cask.coopr.scheduler.task.TaskId;
 import co.cask.coopr.scheduler.task.TaskService;
+import co.cask.coopr.spec.ProvisionerAction;
 import co.cask.coopr.spec.service.Service;
 import co.cask.coopr.store.cluster.ClusterStore;
 import co.cask.coopr.store.cluster.ClusterStoreService;
@@ -48,6 +49,7 @@ import com.google.inject.name.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,10 +123,9 @@ public class JobScheduler implements Runnable {
           boolean jobFailed = job.getJobStatus() == ClusterJob.Status.FAILED;
           int completedTasks = 0;
           int inProgressTasks = 0;
-          int createFailedTasks = 0;
           Set<ClusterTask> notSubmittedTasks = Sets.newHashSet();
           Set<ClusterTask> retryTasks = Sets.newHashSet();
-          // TODO: avoid looking up every single task every time
+          // TODO: avoid looking up every single task every time, or at least do a batch lookup
           LOG.debug("Verifying task statuses for stage {} for job {}", job.getCurrentStageNumber(), jobIdStr);
           for (String taskId : currentStage) {
             ClusterTask task = clusterStore.getClusterTask(TaskId.fromString(taskId));
@@ -140,10 +141,6 @@ public class JobScheduler implements Runnable {
                 retryTasks.add(task);
               } else {
                 jobFailed = true;
-              }
-              // special case: try to determine if creates failed before anything could really be created
-              if (job.getClusterAction() == ClusterAction.CLUSTER_CREATE && task.failedBeforeCreate()) {
-                ++createFailedTasks;
               }
             } else if (task.getStatus() == ClusterTask.Status.IN_PROGRESS) {
               ++inProgressTasks;
@@ -186,9 +183,13 @@ public class JobScheduler implements Runnable {
           } else if (inProgressTasks == 0) {
             // special case: if all tasks were create tasks and all of them failed before they created anything,
             // set the cluster state to 'terminated' instead of letting it go to 'incomplete'.
-            if (createFailedTasks == currentStage.size()) {
-              taskService.failJobAndTerminateCluster(job, cluster,
-                                                     "Unable to create nodes, please check your provider settings");
+            if (job.getClusterAction() == ClusterAction.CLUSTER_CREATE && allCreateTasksFailed(job)) {
+              String message = job.getStatusMessage();
+              // job could have been aborted before any tasks were taken. Keep abort message if that was the case.
+              if (message == null || message.isEmpty()) {
+                message = "Unable to create nodes, please check your provider settings";
+              }
+              taskService.failJobAndTerminateCluster(job, cluster, message);
             } else {
               // Job failed and no in progress tasks remaining, update cluster status
               taskService.failJobAndSetClusterStatus(job, cluster);
@@ -206,6 +207,30 @@ public class JobScheduler implements Runnable {
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
     }
+  }
+
+  // check that every task that ran failed, and that every failure was a cluster create, and that every failure
+  // failed in a way where no resources were actually created (for ex, if provider settings are wrong).
+  private boolean allCreateTasksFailed(ClusterJob job) throws IOException {
+    for (Map.Entry<String, ClusterTask.Status> entry : job.getTaskStatus().entrySet()) {
+      String taskId = entry.getKey();
+      ClusterTask.Status taskStatus = entry.getValue();
+      // no task can succeed or be in progress
+      if (taskStatus == ClusterTask.Status.COMPLETE || taskStatus == ClusterTask.Status.IN_PROGRESS) {
+        return false;
+      }
+      if (taskStatus == ClusterTask.Status.FAILED) {
+        // looks up every failed task... not so great.  But it should be roughly equal to the # of nodes in the cluster.
+        ClusterTask task = clusterStore.getClusterTask(TaskId.fromString(taskId));
+        // check it is a create task
+        if (!task.failedBeforeCreate()) {
+          return false;
+        }
+      }
+    }
+    // if we get here, we only have failed, dropped, or not submitted tasks, and all the failed tasks failed before
+    // they could create anything
+    return true;
   }
 
   private void submitTasks(Set<ClusterTask> notSubmittedTasks, Cluster cluster, Map<String, Node> nodeMap,

--- a/coopr-server/src/main/java/co/cask/coopr/scheduler/task/ClusterTask.java
+++ b/coopr-server/src/main/java/co/cask/coopr/scheduler/task/ClusterTask.java
@@ -245,6 +245,16 @@ public class ClusterTask {
     attempts.add(new TaskAttempt(attempts.size() + 1));
   }
 
+  /**
+   * Return whether or not the task failed before it could create any resources, such as a node or a disk.
+   *
+   * @return true if the task failed before it could create any resources, false if not
+   */
+  public boolean failedBeforeCreate() {
+    int code = getStatusCode();
+    return clusterAction == ClusterAction.CLUSTER_CREATE && code > 199 && code < 300;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)

--- a/coopr-server/src/main/java/co/cask/coopr/store/cluster/ClusterStoreView.java
+++ b/coopr-server/src/main/java/co/cask/coopr/store/cluster/ClusterStoreView.java
@@ -1,13 +1,8 @@
 package co.cask.coopr.store.cluster;
 
 import co.cask.coopr.cluster.Cluster;
-import co.cask.coopr.cluster.ClusterSummary;
-import co.cask.coopr.cluster.Node;
-import co.cask.coopr.scheduler.task.ClusterJob;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Set;
 
 /**
  * A view of the cluster store as seen by a given account.

--- a/coopr-server/src/test/java/co/cask/coopr/http/ClusterHandlerTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/http/ClusterHandlerTest.java
@@ -707,7 +707,8 @@ public class ClusterHandlerTest extends ServiceTestBase {
     Assert.assertNull(task);
     jobScheduler.run();
 
-    assertStatusWithUser1(clusterId, Cluster.Status.INCOMPLETE, ClusterJob.Status.FAILED,
+    // no tasks were run, so the cluster should be in terminated state
+    assertStatusWithUser1(clusterId, Cluster.Status.TERMINATED, ClusterJob.Status.FAILED,
                           ClusterAction.CLUSTER_CREATE, 3, 0);
 
     response = doGet("/clusters/" + clusterId, USER1_HEADERS);
@@ -762,7 +763,8 @@ public class ClusterHandlerTest extends ServiceTestBase {
 
     jobScheduler.run();
 
-    assertStatusWithUser1(clusterId, Cluster.Status.INCOMPLETE, ClusterJob.Status.FAILED,
+    // no tasks were taken, so cluster should be in terminated state
+    assertStatusWithUser1(clusterId, Cluster.Status.TERMINATED, ClusterJob.Status.FAILED,
                           ClusterAction.CLUSTER_CREATE, 3, 0);
 
     response = doGet("/clusters/" + clusterId, USER1_HEADERS);
@@ -819,7 +821,8 @@ public class ClusterHandlerTest extends ServiceTestBase {
 
     jobScheduler.run();
 
-    assertStatusWithUser1(clusterId, Cluster.Status.INCOMPLETE, ClusterJob.Status.FAILED,
+    // no tasks were taken so cluster should move to terminated state
+    assertStatusWithUser1(clusterId, Cluster.Status.TERMINATED, ClusterJob.Status.FAILED,
                           ClusterAction.CLUSTER_CREATE, 3, 0);
 
     response = doGet("/clusters/" + clusterId, USER1_HEADERS);


### PR DESCRIPTION
'incomplete' if all create tasks failed in this manner.
