### PR TITLE
Use status 201 for Unauthorized

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -53,6 +53,9 @@ class FogProviderAWS < Provider
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
+    rescue Excon::Errors::Unauthorized
+      @result['status'] = 201
+      log.error('Provider credentials invalid/unauthorized')
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderAWS.create:' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderAWS.create: #{e.inspect}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -85,6 +85,10 @@ class FogProviderGoogle < Provider
       @result['result']['ssh-auth']['user'] = sshuser
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource)
       @result['status'] = 0
+    # We assume that no work was done when we get Unauthorized
+    rescue Excon::Errors::Unauthorized
+      @result['status'] = 201
+      log.error('Provider credentials invalid/unauthorized')
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.create: #{e.inspect}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -53,6 +53,9 @@ class FogProviderJoyent < Provider
       @result['result']['ssh-auth']['user'] = @task['config']['sshuser'] || 'root'
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
+    rescue Excon::Errors::Unauthorized
+      @result['status'] = 201
+      log.error('Provider credentials invalid/unauthorized')
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderJoyent.create:' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderJoyent.create: #{e.inspect}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -55,6 +55,9 @@ class FogProviderOpenstack < Provider
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
+    rescue Excon::Errors::Unauthorized
+      @result['status'] = 201
+      log.error('Provider credentials invalid/unauthorized')
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderOpenstack.create:' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderOpenstack.create: #{e.inspect}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -58,6 +58,9 @@ class FogProviderRackspace < Provider
       @result['result']['ssh-auth']['password'] = server.password unless server.password.nil?
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
+    rescue Excon::Errors::Unauthorized
+      @result['status'] = 201
+      log.error('Provider credentials invalid/unauthorized')
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderRackspace.create:' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderRackspace.create: #{e.inspect}"


### PR DESCRIPTION
See caskdata/coopr#649 and COOPR-516 for background information. The idea is to allow the server to know why the task failed, so it can take an appropriate action based off the context of the cluster job.
