### PR TITLE
Feature/coopr templates submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "coopr-templates"]
 	path = coopr-templates
-	url = git@github.com:caskdata/coopr-templates.git
+	url = https://github.com/caskdata/coopr-templates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "coopr-templates"]
+	path = coopr-templates
+	url = git@github.com:caskdata/coopr-templates.git


### PR DESCRIPTION
Add `caskdata/coopr-templates` as a top-level submodule. The idea is to move template-specific code here, such as `coopr-server/config/defaults/load-defaults.sh` for reuse among multiple Coopr-related projects.
