### PR TITLE
prevent potential nullpointer in server startup failure scenarios

### DIFF
--- a/coopr-provisioner/master/lib/provisioner/provisioner.rb
+++ b/coopr-provisioner/master/lib/provisioner/provisioner.rb
@@ -110,7 +110,7 @@ module Coopr
       rescue RuntimeError => e
         log.error "Exception raised in thread: #{e.inspect}, shutting down..."
         # if signal_handler thread alive, use it to shutdown gracefully
-        if @signal_thread.alive?
+        if @signal_thread && @signal_thread.alive?
           Process.kill('TERM', 0)
           @signal_thread.join
           [@heartbeat_thread, @sinatra_thread, @resource_thread].each do |t|


### PR DESCRIPTION
- [x] check var exists before using it... prevents an error I saw triggered when provisioner was unable to startup.
