### PR TITLE
Use public, private, then first address for bootstrap_ip

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -98,7 +98,10 @@ class FogProviderOpenstack < Provider
         (server.addresses['public'] ||= []) << { 'version' => 4, 'addr' => floating_address }
       end
 
-      bootstrap_ip = primary_public_ip_address(server.addresses)
+      bootstrap_ip =
+        primary_public_ip_address(server.addresses) ||
+        primary_private_ip_address(server.addresses) ||
+        server.addresses.first[1][0]['addr']
       if bootstrap_ip.nil?
         log.error 'No IP address available for bootstrapping.'
         fail 'No IP address available for bootstrapping.'


### PR DESCRIPTION
This resolves an issue where the provisioner is on the same network as the instance being provisioned, a floating IP address has not been requested, and there is no network named `public` or `private` to detect.
