### PR TITLE
Added ability to specify non default Gson object to RestClient.

### DIFF
--- a/coopr-rest-client/README.md
+++ b/coopr-rest-client/README.md
@@ -37,7 +37,8 @@ The Rest Client Java API is for managing Coopr from Java applications.
   - ssl: false (use HTTP protocol) 
   - version : 'v2' (Coopr server version, used as a part of the base URI [http(s)://localhost:55054/v2/...]) 
   - apiKey:  null (Need to specify to authenticate client requests)
-  - verifySSLCert: true (By default, SSL Certificate verification is enabled) 
+  - verifySSLCert: true (By default, SSL Certificate verification is enabled)
+  - gson: new Gson() (Gson instance with the default configurations) 
    
  ```
    ClientManager clientManager = RestClientManager.builder("localhost", 55054)

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/AdminRestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/AdminRestClient.java
@@ -22,6 +22,7 @@ import co.cask.coopr.spec.ImageType;
 import co.cask.coopr.spec.Provider;
 import co.cask.coopr.spec.service.Service;
 import co.cask.coopr.spec.template.ClusterTemplate;
+import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -49,6 +50,10 @@ public class AdminRestClient extends RestClient implements AdminClient {
 
   public AdminRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
     super(config, httpClient);
+  }
+
+  public AdminRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
+    super(config, httpClient, gson);
   }
 
   @Override

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/ClusterRestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/ClusterRestClient.java
@@ -28,6 +28,7 @@ import co.cask.coopr.http.request.ClusterStatusResponse;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
@@ -59,6 +60,10 @@ public class ClusterRestClient extends RestClient implements ClusterClient {
 
   public ClusterRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
     super(config, httpClient);
+  }
+
+  public ClusterRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
+    super(config, httpClient, gson);
   }
 
   @Override
@@ -150,7 +155,7 @@ public class ClusterRestClient extends RestClient implements ClusterClient {
   @Override
   public void setClusterExpireTime(String clusterId, long expireTime) throws IOException {
     HttpPost postRequest = new HttpPost(buildFullURL(String.format("/clusters/%s", clusterId)));
-    StringEntity entity = new StringEntity(GSON.toJson(ImmutableMap.of(EXPIRE_TIME_ATTRIBUTE_NAME, expireTime)));
+    StringEntity entity = new StringEntity(getGson().toJson(ImmutableMap.of(EXPIRE_TIME_ATTRIBUTE_NAME, expireTime)));
     entity.setContentType(MediaType.APPLICATION_JSON);
     postRequest.setEntity(entity);
     LOG.debug("Set a cluster expiration timestamp to the new value {}.", expireTime);

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/PluginRestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/PluginRestClient.java
@@ -21,6 +21,7 @@ import co.cask.coopr.provisioner.plugin.ResourceMeta;
 import co.cask.coopr.provisioner.plugin.ResourceStatus;
 import co.cask.coopr.spec.plugin.AutomatorType;
 import co.cask.coopr.spec.plugin.ProviderType;
+import com.google.gson.Gson;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -39,6 +40,10 @@ public class PluginRestClient extends RestClient implements PluginClient {
 
   public PluginRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
     super(config, httpClient);
+  }
+
+  public PluginRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
+    super(config, httpClient, gson);
   }
 
   @Override

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/ProvisionerRestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/ProvisionerRestClient.java
@@ -18,6 +18,7 @@ package co.cask.coopr.client.rest;
 
 import co.cask.coopr.client.ProvisionerClient;
 import co.cask.coopr.provisioner.Provisioner;
+import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -36,6 +37,10 @@ public class ProvisionerRestClient extends RestClient implements ProvisionerClie
 
   public ProvisionerRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
     super(config, httpClient);
+  }
+
+  public ProvisionerRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
+    super(config, httpClient, gson);
   }
 
   @Override

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestClient.java
@@ -55,14 +55,17 @@ public class RestClient {
   private static final String COOPR_TENANT_ID_HEADER_NAME = "Coopr-TenantID";
   private static final String COOPR_USER_ID_HEADER_NAME = "Coopr-UserID";
 
-  protected static final Gson GSON = new Gson();
-
+  private final Gson gson;
   private final RestClientConnectionConfig config;
   private final URI baseUrl;
   private final CloseableHttpClient httpClient;
   private final Header[] authHeaders;
 
   public RestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
+    this(config, httpClient, new Gson());
+  }
+
+  public RestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(config.getUserId()), "User ID couldn't be null");
     Preconditions.checkArgument(!Strings.isNullOrEmpty(config.getTenantId()), "Tenant ID couldn't be null");
     this.config = config;
@@ -70,6 +73,7 @@ public class RestClient {
                                             config.getHost(), config.getPort(), config.getVersion()));
     this.httpClient = httpClient;
     this.authHeaders = getAuthHeaders();
+    this.gson = gson;
   }
 
   /**
@@ -131,7 +135,7 @@ public class RestClient {
     List<T> resultList;
     try {
       RestClient.analyzeResponseCode(httpResponse);
-      resultList = GSON.fromJson(EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8), type);
+      resultList = gson.fromJson(EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8), type);
     } finally {
       httpResponse.close();
     }
@@ -148,7 +152,7 @@ public class RestClient {
     T result;
     try {
       RestClient.analyzeResponseCode(httpResponse);
-      result = GSON.fromJson(EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8), type);
+      result = gson.fromJson(EntityUtils.toString(httpResponse.getEntity(), Charsets.UTF_8), type);
     } finally {
       httpResponse.close();
     }
@@ -167,7 +171,7 @@ public class RestClient {
 
   protected <T> void addRequestBody(HttpEntityEnclosingRequestBase requestBase, T body) {
     if (body != null) {
-      StringEntity stringEntity = new StringEntity(GSON.toJson(body), Charsets.UTF_8);
+      StringEntity stringEntity = new StringEntity(gson.toJson(body), Charsets.UTF_8);
       requestBase.setEntity(stringEntity);
       LOG.debug("Added the json request body: {}.", stringEntity);
     }
@@ -193,5 +197,12 @@ public class RestClient {
    */
   public URI getBaseURL() {
     return baseUrl;
+  }
+
+  /**
+   * @return the configured gson object
+   */
+  public Gson getGson() {
+    return gson;
   }
 }

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestClientManager.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestClientManager.java
@@ -22,6 +22,7 @@ import co.cask.coopr.client.ClusterClient;
 import co.cask.coopr.client.PluginClient;
 import co.cask.coopr.client.ProvisionerClient;
 import co.cask.coopr.client.TenantClient;
+import com.google.gson.Gson;
 import org.apache.http.config.Registry;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -44,6 +45,7 @@ public class RestClientManager implements ClientManager {
   private static final String DEFAULT_VERSION = "v2";
   private static final boolean DEFAULT_SSL = false;
   private static final boolean DEFAULT_VERIFY_SSL_CERT = true;
+  private static final Gson DEFAULT_GSON_INSTANCE = new Gson();
 
   private final AdminClient adminClient;
   private final ClusterClient clusterClient;
@@ -68,11 +70,11 @@ public class RestClientManager implements ClientManager {
     }
     this.httpClient = HttpClients.custom().setConnectionManager(createConnectionManager()).build();
 
-    this.adminClient = new AdminRestClient(connectionConfig, httpClient);
-    this.clusterClient = new ClusterRestClient(connectionConfig, httpClient);
-    this.pluginClient = new PluginRestClient(connectionConfig, httpClient);
-    this.provisionerClient = new ProvisionerRestClient(connectionConfig, httpClient);
-    this.tenantClient = new TenantRestClient(connectionConfig, httpClient);
+    this.adminClient = new AdminRestClient(connectionConfig, httpClient, builder.gson);
+    this.clusterClient = new ClusterRestClient(connectionConfig, httpClient, builder.gson);
+    this.pluginClient = new PluginRestClient(connectionConfig, httpClient, builder.gson);
+    this.provisionerClient = new ProvisionerRestClient(connectionConfig, httpClient, builder.gson);
+    this.tenantClient = new TenantRestClient(connectionConfig, httpClient, builder.gson);
   }
 
   /**
@@ -139,6 +141,7 @@ public class RestClientManager implements ClientManager {
     private String version = DEFAULT_VERSION;
     private String userId;
     private String tenantId;
+    private Gson gson = DEFAULT_GSON_INSTANCE;
 
     public Builder(String host, int port) {
       this.host = host;
@@ -167,6 +170,11 @@ public class RestClientManager implements ClientManager {
 
     public Builder userId(String userId) {
       this.userId = userId;
+      return this;
+    }
+
+    public Builder gson(Gson gson) {
+      this.gson = gson;
       return this;
     }
 

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestUtil.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/RestUtil.java
@@ -72,4 +72,6 @@ public final class RestUtil {
       .register("http", PlainConnectionSocketFactory.getSocketFactory())
       .build();
   }
+
+
 }

--- a/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/TenantRestClient.java
+++ b/coopr-rest-client/src/main/java/co/cask/coopr/client/rest/TenantRestClient.java
@@ -18,6 +18,7 @@ package co.cask.coopr.client.rest;
 
 import co.cask.coopr.client.TenantClient;
 import co.cask.coopr.spec.TenantSpecification;
+import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -36,6 +37,10 @@ public class TenantRestClient extends RestClient implements TenantClient {
 
   public TenantRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient) {
     super(config, httpClient);
+  }
+
+  public TenantRestClient(RestClientConnectionConfig config, CloseableHttpClient httpClient, Gson gson) {
+    super(config, httpClient, gson);
   }
 
   @Override


### PR DESCRIPTION
So far as exists ability to create `Gson` object not only with default constructor, but also using `GsonBuilder`, I added new constructor to the `RestClient` which allows to specify non default `Gson` object for json serialization and deserialization. @albertshau , please review this changes.
