### PR TITLE
Reverse order to prevent null pointer

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/coopr-provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -243,7 +243,7 @@ class ShellAutomator < Automator
     @result['status'] = 0
     log.debug "ShellAutomator bootstrap completed successfully: #{@result}"
   ensure
-    File.delete(@ssh_file) if File.exist?(@ssh_file) && @ssh_file
+    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
   end
 
   def install(inputmap)


### PR DESCRIPTION
This is already done in `chef_solo_automator` and `fog_provider` but we missed changing it in `shell_automator` to match.
