### PR TITLE
Set sudo variable before using it

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -119,7 +119,8 @@ class FogProviderOpenstack < Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bind_ip
       }
-      # Additional checks
+      # do we need sudo bash?
+      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option


### PR DESCRIPTION
Fixes this error:

```
2014-10-22 15:31:08 -0400 worker-superadmin-3 ERROR: Unexpected Error Occurred in FogProviderOpenstack.confirm:#<NameError: undefined local variable or method `sudo' for #<FogProviderOpenstack:0x00000003021630>>
```
