### PR TITLE
Better output on credential failures

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -54,10 +54,12 @@ class FogProviderAWS < Provider
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue Excon::Errors::Unauthorized
+      msg = 'Provider credentials invalid/unauthorized'
       @result['status'] = 201
-      log.error('Provider credentials invalid/unauthorized')
+      @result['stderr'] = msg
+      log.error(msg)
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderAWS.create:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderAWS.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderAWS.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -234,7 +236,7 @@ class FogProviderAWS < Provider
       log.error("SSH Authentication failure for #{providerid}/#{bootstrap_ip}")
       @result['stderr'] = "SSH Authentication failure for #{providerid}/#{bootstrap_ip}: #{e.inspect}"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderAWS.confirm:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderAWS.confirm: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderAWS.confirm: #{e.inspect}"
     else
       log.debug "Confirm finished successfully: #{@result}"
@@ -264,7 +266,7 @@ class FogProviderAWS < Provider
       # Return 0
       @result['status'] = 0
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderAWS.delete:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderAWS.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderAWS.delete: #{e.inspect}"
     else
       log.debug "Delete finished sucessfully: #{@result}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -87,10 +87,12 @@ class FogProviderGoogle < Provider
       @result['status'] = 0
     # We assume that no work was done when we get Unauthorized
     rescue Excon::Errors::Unauthorized
+      msg = 'Provider credentials invalid/unauthorized'
       @result['status'] = 201
-      log.error('Provider credentials invalid/unauthorized')
+      @result['stderr'] = msg
+      log.error(msg)
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderGoogle.create:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderGoogle.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -207,7 +209,7 @@ class FogProviderGoogle < Provider
       log.error("SSH Authentication failure for #{providerid}/#{bootstrap_ip}")
       @result['stderr'] = "SSH Authentication failure for #{providerid}/#{bootstrap_ip}: #{e.inspect}"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderGoogle.confirm:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderGoogle.confirm: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.confirm: #{e.inspect}"
     else
       log.debug "Confirm finished successfully: #{@result}"
@@ -290,7 +292,7 @@ class FogProviderGoogle < Provider
       log.error('Unable to delete specified components: ' + e.inspect)
       @result['stderr'] = "Unable to delete specified components: ' + e.inspect"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderGoogle.delete:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderGoogle.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.delete: #{e.inspect}"
     else
       log.debug "Delete finished sucessfully: #{@result}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -54,10 +54,12 @@ class FogProviderJoyent < Provider
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue Excon::Errors::Unauthorized
+      msg = 'Provider credentials invalid/unauthorized'
       @result['status'] = 201
-      log.error('Provider credentials invalid/unauthorized')
+      @result['stderr'] = msg
+      log.error(msg)
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderJoyent.create:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderJoyent.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderJoyent.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -191,7 +193,7 @@ class FogProviderJoyent < Provider
       log.error("SSH Authentication failure for #{providerid}/#{bootstrap_ip}")
       @result['stderr'] = "SSH Authentication failure for #{providerid}/#{bootstrap_ip}: #{e.inspect}"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderJoyent.confirm:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderJoyent.confirm: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderJoyent.confirm: #{e.inspect}"
     else
       log.debug "Confirm finished successfully: #{@result}"
@@ -221,7 +223,7 @@ class FogProviderJoyent < Provider
       # Return 0
       @result['status'] = 0
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderJoyent.delete:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderJoyent.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderJoyent.delete: #{e.inspect}"
     else
       log.debug "Delete finished sucessfully: #{@result}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -59,10 +59,12 @@ class FogProviderOpenstack < Provider
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue Excon::Errors::Unauthorized
+      msg = 'Provider credentials invalid/unauthorized'
       @result['status'] = 201
-      log.error('Provider credentials invalid/unauthorized')
+      @result['stderr'] = msg
+      log.error(msg)
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderOpenstack.create:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderOpenstack.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderOpenstack.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -143,7 +145,7 @@ class FogProviderOpenstack < Provider
       log.error("SSH Authentication failure for #{providerid}/#{bootstrap_ip}")
       @result['stderr'] = "SSH Authentication failure for #{providerid}/#{bootstrap_ip}: #{e.inspect}"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderOpenstack.confirm:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderOpenstack.confirm: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderOpenstack.confirm: #{e.inspect}"
     else
       log.debug "Confirm finished successfully: #{@result}"
@@ -171,7 +173,7 @@ class FogProviderOpenstack < Provider
       # Return 0
       @result['status'] = 0
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderOpenstack.delete:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderOpenstack.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderOpenstack.delete: #{e.inspect}"
     else
       log.debug "Delete finished sucessfully: #{@result}"

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -59,10 +59,12 @@ class FogProviderRackspace < Provider
       @result['result']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @ssh_key_resource) unless @ssh_key_resource.nil?
       @result['status'] = 0
     rescue Excon::Errors::Unauthorized
+      msg = 'Provider credentials invalid/unauthorized'
       @result['status'] = 201
-      log.error('Provider credentials invalid/unauthorized')
+      @result['stderr'] = msg
+      log.error(msg)
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderRackspace.create:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderRackspace.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderRackspace.create: #{e.inspect}"
     else
       log.debug "Create finished successfully: #{@result}"
@@ -133,7 +135,7 @@ class FogProviderRackspace < Provider
       log.error("SSH Authentication failure for #{providerid}/#{bootstrap_ip}")
       @result['stderr'] = "SSH Authentication failure for #{providerid}/#{bootstrap_ip}: #{e.inspect}"
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderRackspace.confirm:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderRackspace.confirm: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderRackspace.confirm: #{e.inspect}"
     else
       log.debug "Confirm finished successfully: #{@result}"
@@ -161,7 +163,7 @@ class FogProviderRackspace < Provider
       # Return 0
       @result['status'] = 0
     rescue => e
-      log.error('Unexpected Error Occurred in FogProviderRackspace.delete:' + e.inspect)
+      log.error('Unexpected Error Occurred in FogProviderRackspace.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderRackspace.delete: #{e.inspect}"
     else
       log.debug "Delete finished sucessfully: #{@result}"


### PR DESCRIPTION
The important takeaway is assigning an error message to `@result['stderr']` which makes it available to callbacks.
