### PR TITLE
revert to angular 1.2.x + other fixes missed in previous PRs

### DIFF
--- a/coopr-ngui/app/index.html
+++ b/coopr-ngui/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" ng-app="coopr-ngui" ng-strict-di>
+<html lang="en" ng-app="coopr-ngui">
 <head>
     <title ng-bind="$state.current | myTitleFilter">Coopr</title>
 

--- a/coopr-ngui/app/js/controllers/provider/form-ctrl.js
+++ b/coopr-ngui/app/js/controllers/provider/form-ctrl.js
@@ -40,7 +40,6 @@ function ($scope, $state, $q, myApi, CrudFormBase, myFocusManager) {
   });
 
 
-
   function findProvider (pName) {
     var p = $scope.providerTypes.filter(function (item) {
       return item.name === pName;

--- a/coopr-ngui/app/js/controllers/subnav-ctrl.js
+++ b/coopr-ngui/app/js/controllers/subnav-ctrl.js
@@ -12,7 +12,6 @@ function ($scope, $state, myApi) {
 
   fetchSubnavList();
 
-
   /* ----------------------------------------------------------------------- */
 
   function fetchSubnavList () {

--- a/coopr-ngui/app/js/routes.js
+++ b/coopr-ngui/app/js/routes.js
@@ -152,7 +152,7 @@ angular.module(PKG.name)
       return {
         name: stateName,
         abstract: true,
-        templateUrl: '/partials/subnav.html',
+        templateUrl: '/assets/partials/subnav.html',
         controller: 'SubnavCtrl',
         url: '/' + stateName,
         data: angular.extend({

--- a/coopr-ngui/app/partials/clusters/form.html
+++ b/coopr-ngui/app/partials/clusters/form.html
@@ -38,7 +38,7 @@
 
   </div>
 
-  <div ng-include="'/partials/clusters/form-advanced.html'" ng-show="showAdvanced" class="am-fade-and-slide-right"></div>
+  <div ng-include="'/assets/partials/clusters/form-advanced.html'" ng-show="showAdvanced" class="am-fade-and-slide-right"></div>
 
   <div class="form-group" ng-show="showConfig">
     <label for="inputClusterConfig" class="col-xs-2 control-label">Config</label>

--- a/coopr-ngui/app/partials/providers/form.html
+++ b/coopr-ngui/app/partials/providers/form.html
@@ -30,7 +30,7 @@
         class="form-control"
         ng-model="model.providertype"
         ng-options="pType.name as pType.name for pType in providerTypes"
-        ng-readonly="editing"
+        ng-disabled="editing"
       ></select>
     </div>
   </div>

--- a/coopr-ngui/app/partials/templates/form.html
+++ b/coopr-ngui/app/partials/templates/form.html
@@ -12,7 +12,7 @@
     <fieldset data-title="{{tab.title}}" ng-repeat="tab in tabs" bs-pane>
 
       <div 
-        ng-include="'/partials/templates/'+tab.partial"
+        ng-include="'/assets/partials/templates/'+tab.partial"
         onload="onTabLoaded($index)"
       ></div>
 

--- a/coopr-ngui/bower.json
+++ b/coopr-ngui/bower.json
@@ -2,11 +2,11 @@
   "name": "coopr-ngui",
   "private": true,
   "dependencies": {
-    "angular": "1.3.0",
-    "angular-animate": "1.3.0",
-    "angular-sanitize": "1.3.0",
-    "angular-resource": "1.3.0",
-    "angular-mocks": "1.3.0",
+    "angular": "1.2.26",
+    "angular-animate": "1.2.26",
+    "angular-sanitize": "1.2.26",
+    "angular-resource": "1.2.26",
+    "angular-mocks": "1.2.26",
 
     "bootstrap": "3.2.0",
     "font-awesome": "4.2.0",


### PR DESCRIPTION
I think we are being hit by the issues mentioned on https://docs.angularjs.org/api/ng/directive/select

```
 ngModel compares by reference, not value. This is important when binding to an array of objects. See an example in http://jsfiddle.net/qWzTb/.
```
