### PR TITLE
Feature/remove sauce temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_install:
 before_script:
   - 'cd coopr-ngui && npm run build'
   - 'npm start > /dev/null &'
-  - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then cd ../coopr-server; fi'
+  - 'cd ..'
+  - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then cd coopr-server; fi'
   - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then mvn clean package assembly:single -DskipTests; fi'
   - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then cd ..; fi'
   - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then java -cp coopr-server/target/*:coopr-e2e/config co.cask.coopr.runtime.ServerMain; fi >/dev/null 2>&1 &'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,17 @@ language: java
 
 jdk:
   - oraclejdk7
+## Commenting it out by @ajainarayanan @gaarf as sauce doesn't taste good.
 
-env:
-  global:
-    - secure: DHoIe2FobpAM/4ZKZX3acpBN/UPQn1FK+OJG87IuvCJ2xQbXMOimIL5l52/PgEbea9wQC+qxOaXhFkDS0SMq+AWw0Haa+b0xUG+D9SdRsMfipBmhHowKNAxRkVp1DE563cibpUv03DbS+XWL1xWv0xrc+ooPKdzZm2jWwAlW1AI=
-    - secure: DIURQkS/L8U3TTXTtmhhDLdNJAfB2NqUMb6+K5EYwFS/C37tNPTl1ip23j/KC4PRboJtFNgVqQFo9ErsYY7xk6md6+JCB6Tl/4CzSvtZ6Z9xVssFPdKA6dOryelG6beckGoxfWxSw4zIcx2aODVIkMLR+/86Y+9XJ6pJbkfeGEo=
-    - COOPR_SERVER_HOME=`pwd`/coopr-server
-    - COOPR_SERVER_URI=http://127.0.0.1:55054
-    - COOPR_USE_DUMMY_PROVISIONER=true
-addons:
-  sauce_connect: true
+# env:
+#   global:
+#     - secure: DHoIe2FobpAM/4ZKZX3acpBN/UPQn1FK+OJG87IuvCJ2xQbXMOimIL5l52/PgEbea9wQC+qxOaXhFkDS0SMq+AWw0Haa+b0xUG+D9SdRsMfipBmhHowKNAxRkVp1DE563cibpUv03DbS+XWL1xWv0xrc+ooPKdzZm2jWwAlW1AI=
+#     - secure: DIURQkS/L8U3TTXTtmhhDLdNJAfB2NqUMb6+K5EYwFS/C37tNPTl1ip23j/KC4PRboJtFNgVqQFo9ErsYY7xk6md6+JCB6Tl/4CzSvtZ6Z9xVssFPdKA6dOryelG6beckGoxfWxSw4zIcx2aODVIkMLR+/86Y+9XJ6pJbkfeGEo=
+#     - COOPR_SERVER_HOME=`pwd`/coopr-server
+#     - COOPR_SERVER_URI=http://127.0.0.1:55054
+#     - COOPR_USE_DUMMY_PROVISIONER=true
+# addons:
+#   sauce_connect: true
 
 branches:
   only:
@@ -63,4 +64,3 @@ script:
   - 'if [ -n "$SAUCE_ACCESS_KEY" ]; then npm run protractor; fi'
   - 'cd ..'
   - 'mvn test'
-

--- a/coopr-e2e/test/protractor-conf.js
+++ b/coopr-e2e/test/protractor-conf.js
@@ -2,8 +2,7 @@ var config = {
   allScriptsTimeout: 11000,
 
   specs: [
-    // 'e2e/**/*.js'
-    'e2e/providers/*.js'
+    'e2e/**/*.js'
   ],
 
   capabilities: {


### PR DESCRIPTION
- Removes sauce temporarily until we finalize if the test environment is configured wrong or the tests in itself.
- Unblock backend as integration tests should not block backend to commit and merge stuff.
