### PR TITLE
COOPR-553 include the sonatype snapshots maven repo until the

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
         <developerConnection>scm:git:git://github.com/caskdata/coopr.git</developerConnection>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>sonatype.snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <repository>
             <id>sonatype.release</id>


### PR DESCRIPTION
common-cli artifact is released.
