### PR TITLE
Create node_modules cookbook

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/README.md
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/README.md
@@ -1,0 +1,12 @@
+Description
+===========
+
+Requirements
+============
+
+Attributes
+==========
+
+Usage
+=====
+

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/metadata.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/metadata.rb
@@ -1,0 +1,9 @@
+name             'node_modules'
+maintainer       'Cask Data, Inc'
+maintainer_email 'ops@cask.co'
+license          'Apache 2.0'
+description      'Installs Node.JS modules using the nodejs_npm LWRP'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+
+depends 'nodejs'

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/recipes/default.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/node_modules/recipes/default.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: node_modules
+# Recipe:: default
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install Node.JS modules, from a list
+if node['nodejs'].key?('modules')
+  node['nodejs']['modules'].each do |m|
+    nodejs_npm m do
+      action :install
+    end
+  end
+end


### PR DESCRIPTION
This is a simple cookbook to use the `nodejs_npm` LWRP provided by the `nodejs` cookbook to allow us to install modules for Node.JS into a cluster created by Coopr.
