### PR TITLE
Feature/docs update add your own cookbook

### DIFF
--- a/coopr-docs/docs/source/guide/superadmin/chef-solo-automator-plugin.rst
+++ b/coopr-docs/docs/source/guide/superadmin/chef-solo-automator-plugin.rst
@@ -173,18 +173,20 @@ Since the Chef Solo Automator plugin is implemented using chef-solo, the followi
 Cookbooks should be fully attribute-driven. At this time the Chef Solo Automator does not support the chef-solo "environment" primitive. 
 Attributes normally specified in an environment can instead be populated in Coopr primitives such as cluster templates or service action data.
 
-In order to add cookbooks, roles, or data-bags for use by the provisioners, simply add them to the local chef directories for the Chef Solo Automator
-plugin. If using the default package install, these directories are currently:
-::
+**Cookbooks as plugin resources**
 
-    /opt/coopr/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks
-    /opt/coopr/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/roles
-    /opt/coopr/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/data_bags
+The Chef Solo Automator utilizes the :doc:`Plugin Resources </guide/admin/plugin-resources>` capability of Coopr in order to manage cookbooks, data bags, and roles.  Each of these chef primitives can be uploaded to the Coopr server individually as resources.  Refer to the :doc:`Plugin Resources Guide </guide/admin/plugin-resources>` for more details on plugin resource management.
 
-Your cookbook should be readable by the 'coopr-provisioner' user (default: 'coopr'). The next provisioner which runs a
-bootstrap task will regenerate the local tarballs
-(for example ``/opt/coopr/provisioner/daemon/plugins/automators/chef_solo_automator/chef_solo_automator/cookbooks.tar.gz``) and it will be
-available for use when chef-solo runs on the remote box.
+Examples:
+
+	* /opt/coopr/provisioner/embedded/bin/ruby /opt/coopr/provisioner/bin/data-uploader.rb -u http://localhost:55054 -t superadmin -U admin sync ./my/local/cookbooks/myapp automatortypes/chef-solo/cookbooks/myapp
+	* /opt/coopr/provisioner/embedded/bin/ruby /opt/coopr/provisioner/bin/data-uploader.rb -u http://localhost:55054 -t superadmin -U admin sync ./my/local/data_bags/mydata_bag automatortypes/chef-solo/data_bags/my_data_bag
+	* /opt/coopr/provisioner/embedded/bin/ruby /opt/coopr/provisioner/bin/data-uploader.rb -u http://localhost:55054 -t superadmin -U admin sync ./my/local/roles/my_role.rb automatortypes/chef-solo/cookbooks/my_role.rb
+
+.. note:: If you are uploading an archive of a directory, the top level directory of your unpacked archive must be named exactly the same as your resource name. For example, if you are uploading an archive of a directory named 'mycookbook', you *must* name your resource 'mycookbook' in order for it to be used correctly. This issue will be fixed in the next release. 
+
+
+**Invoking your Cookbook**
 
 In order to actually invoke your cookbook or role as part of a cluster provision, you will need to define a Coopr service
 definition with the following parameters:

--- a/coopr-docs/docs/source/guide/superadmin/chef-solo-automator-plugin.rst
+++ b/coopr-docs/docs/source/guide/superadmin/chef-solo-automator-plugin.rst
@@ -175,7 +175,7 @@ Attributes normally specified in an environment can instead be populated in Coop
 
 **Cookbooks as plugin resources**
 
-The Chef Solo Automator utilizes the :doc:`Plugin Resources </guide/admin/plugin-resources>` capability of Coopr in order to manage cookbooks, data bags, and roles.  Each of these chef primitives can be uploaded to the Coopr server individually as resources.  Refer to the :doc:`Plugin Resources Guide </guide/admin/plugin-resources>` for more details on plugin resource management.
+The Chef Solo Automator utilizes the :doc:`Plugin Resources </guide/admin/plugin-resources>` capability of Coopr in order to manage cookbooks, data bags, and roles.  Each of these Chef primitives can be uploaded to the Coopr server individually as resources.  Refer to the :doc:`Plugin Resources Guide </guide/admin/plugin-resources>` for more details on plugin resource management.
 
 Examples:
 

--- a/coopr-docs/docs/source/guide/superadmin/shell-automator-plugin.rst
+++ b/coopr-docs/docs/source/guide/superadmin/shell-automator-plugin.rst
@@ -129,9 +129,23 @@ key names, etc).
 Adding your own Scripts
 =======================
 
-	1. add your script to the ``$COOPR_HOME/provisioner/daemon/plugins/automators/shell_automator/scripts`` directory.
-	2. add/edit a service definition with an action of type "shell"
-	3. specify the command to run, optional args, and during which stage it should run.
+The Shell Automator utilizes the :doc:`Plugin Resources </guide/admin/plugin-resources>` capability of Coopr in order to manage shell scripts.  Each script can be uploaded to the Coopr server individually as resources.  Refer to the :doc:`Plugin Resources Guide </guide/admin/plugin-resources>` for more details on plugin resource management.
+
+Example:
+
+        * /opt/coopr/provisioner/embedded/bin/ruby /opt/coopr/provisioner/bin/data-uploader.rb -u http://localhost:55054 -t superadmin -U admin sync ./my/local/scripts/my_script.sh automatortypes/shell/scripts/my_script.sh
+
+In order to actually invoke your script as part of a cluster provision, you will need to define a Coopr service
+definition with the following parameters:
+
+        * Category: any action (install, configure, start, stop, etc)
+        * Type: shell
+        * Script: the command to run, note your script will reside in the current working directory, so "my_script.sh" should suffice
+	* Arguments: optional arguments to the script
+
+Then simply add your service to a cluster template.
+
+.. note:: When your script runs, its current working directory will be within the provisioner's work directory.  Any file paths referenced in your script should be absolute.
 
 
 Best Practices


### PR DESCRIPTION
PR to update 0.9.8 release documentation:
- [x] upload your own cookbook section now refers to the plugin resource guide, and gives examples
- [x] upload your own shell script section now is updated, and is similar to above.
