### PR TITLE
Hotfix/missing dev packages

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
@@ -17,10 +17,7 @@
 # limitations under the License.
 #
 
-%w(build-essential dnsimple).each do |recipe|
-  include_recipe recipe
-end
-
+# Install some pre-requisites
 case node['platform_family']
 when 'debian'
   zpkg = 'libz-dev'
@@ -28,7 +25,12 @@ when 'rhel'
   zpkg = 'zlib-devel'
 end
 
-package zpkg
+r = package( zpkg ) { action :nothing }
+r.run_action( :install )
+
+%w(build-essential dnsimple).each do |recipe|
+  include_recipe recipe
+end
 
 # Get credentials
 if node['dnsimple']['username'] && node['dnsimple']['password']

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
@@ -21,6 +21,15 @@
   include_recipe recipe
 end
 
+case node['platform_family']
+when 'debian'
+  zpkg = 'libz-dev'
+when 'rhel'
+  zpkg = 'zlib-devel'
+end
+
+package zpkg
+
 # Get credentials
 if node['dnsimple']['username'] && node['dnsimple']['password']
   dnsimple = node['dnsimple']


### PR DESCRIPTION
Building `fog` requires `nokogiri`, which builds `libxml2`, which is statically-linked against `libz.a`... whew!
