### PR TITLE
Increase default timeout to 10 seconds

### DIFF
--- a/coopr-ngui/app/main.js
+++ b/coopr-ngui/app/main.js
@@ -67,7 +67,7 @@ angular
     $httpProvider.interceptors.push(function () {
       return {
         request: function(config) {
-          config.timeout = 3000; // 3 seconds default
+          config.timeout = 10000; // 10 seconds default
           return config;
         }
       };


### PR DESCRIPTION
After discussion with @gaarf and the possibility of slow client networks and very large returned payloads, especially for the cluster listing page when logged in as admin, I am increasing the default timeout from 3 seconds to 10 seconds.
