### PR TITLE
Feature/fix rspec

### DIFF
--- a/coopr-provisioner/Rakefile
+++ b/coopr-provisioner/Rakefile
@@ -2,7 +2,9 @@
 # encoding: UTF-8
 
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:rspec)
+RSpec::Core::RakeTask.new(:rspec) do |t|
+  t.pattern = 'master/spec/**/*_spec.rb,worker/spec/**/*_spec.rb'
+end
 
 # rubocop rake task
 desc 'Ruby style guide linter'

--- a/coopr-provisioner/spec/default_spec.rb
+++ b/coopr-provisioner/spec/default_spec.rb
@@ -1,2 +1,0 @@
-require_relative '../master/spec/spec_helper'
-require_relative '../worker/spec/spec_helper'

--- a/coopr-provisioner/worker/spec/automator_spec.rb
+++ b/coopr-provisioner/worker/spec/automator_spec.rb
@@ -7,9 +7,10 @@ describe Automator do
 
   # Set these up once
   before :all do
+    env = Hash.new
     %w(bootstrap install configure initialize start stop remove).each do |taskname|
       instance_variable_set("@task_#{taskname}", JSON.parse(response.gsub('BOOTSTRAP', taskname)))
-      instance_variable_set("@automator_#{taskname}", Automator.new(instance_variable_get("@task_#{taskname}")))
+      instance_variable_set("@automator_#{taskname}", Automator.new(env, instance_variable_get("@task_#{taskname}")))
     end
   end
 

--- a/coopr-provisioner/worker/spec/automator_spec.rb
+++ b/coopr-provisioner/worker/spec/automator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative 'spec_helper'
 require 'json'
 
 describe Automator do

--- a/coopr-provisioner/worker/spec/pluginmanager_spec.rb
+++ b/coopr-provisioner/worker/spec/pluginmanager_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative 'spec_helper'
 require 'logger'
 
 include Logging

--- a/coopr-provisioner/worker/spec/provider_spec.rb
+++ b/coopr-provisioner/worker/spec/provider_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative 'spec_helper'
 require 'json'
 
 describe Provider do

--- a/coopr-provisioner/worker/spec/provider_spec.rb
+++ b/coopr-provisioner/worker/spec/provider_spec.rb
@@ -7,9 +7,10 @@ describe Provider do
 
   # Set these up once
   before :all do
+    env = Hash.new
     %w(create confirm delete).each do |taskname|
       instance_variable_set("@task_#{taskname}", JSON.parse(response.gsub('BOOTSTRAP', taskname)))
-      instance_variable_set("@provider_#{taskname}", Provider.new(instance_variable_get("@task_#{taskname}")))
+      instance_variable_set("@provider_#{taskname}", Provider.new(env, instance_variable_get("@task_#{taskname}")))
     end
   end
 


### PR DESCRIPTION
#775 broke rspec.  this fixes it, along with some broken worker tests.

```
mac[00:03:12] derek:coopr-provisioner (feature/fix-rspec)$ bundle exec rake
rubocop -D
Inspecting 35 files
...................................

35 files inspected, no offenses detected
/Users/derek/.rvm/rubies/ruby-1.9.3-p374/bin/ruby -I/Users/derek/.rvm/gems/ruby-1.9.3-p374/gems/rspec-core-3.1.7/lib:/Users/derek/.rvm/gems/ruby-1.9.3-p374/gems/rspec-support-3.1.2/lib /Users/derek/.rvm/gems/ruby-1.9.3-p374/gems/rspec-core-3.1.7/exe/rspec --pattern master/spec/\*\*/\*_spec.rb,worker/spec/\*\*/\*_spec.rb
2014-11-19 00:03:19 -0800 - INFO: provisioner master-dereks-macbook-air-17210 initialized

Sinatra API
#<Rack::MockResponse:0x007fe4233b24f0 @original_headers={"Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"7", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @errors="", @body_string=nil, @status=200, @header={"Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"7", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @chunked=false, @writer=#<Proc:0x007fe4233b2018@/Users/derek/.rvm/gems/ruby-1.9.3-p374/gems/rack-1.5.2/lib/rack/response.rb:27 (lambda)>, @block=nil, @length=7, @body=["UNKNOWN"]>
  should serve status endpoint
#<Rack::MockResponse:0x007fe423c2f420 @original_headers={"Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"12", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @errors="", @body_string=nil, @status=200, @header={"Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"12", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @chunked=false, @writer=#<Proc:0x007fe423c2e750@/Users/derek/.rvm/gems/ruby-1.9.3-p374/gems/rack-1.5.2/lib/rack/response.rb:27 (lambda)>, @block=nil, @length=12, @body=["{\"usage\":{}}"]>
  should serve heartbeat endpoint
2014-11-19 00:03:19 -0800 master-dereks-macbook-air-17210 INFO: adding tenant
2014-11-19 00:03:19 -0800 master-dereks-macbook-air-17210 INFO: adding/updating tenant id: test_tenant
  can do tenant operations
2014-11-19 00:03:19 -0800 master-dereks-macbook-air-17210 INFO: adding tenant
  can delete a tenant with no workers

Provisioner::CLI
  can parse command line arguments

Coopr::Config
  can parse the included config file

Automator
  when taskName is bootstrap
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is install
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is configure
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is initialize
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is start
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is stop
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash
  when taskName is remove
    #new
      creates an instance of Automator
      creates task instance variable
      creates empty result hash

Provider
  when taskName is create
    #new
      creates an instance of Provider
      creates task instance variable
      creates empty result hash
  when taskName is confirm
    #new
      creates an instance of Provider
      creates task instance variable
      creates empty result hash
  when taskName is delete
    #new
      creates an instance of Provider
      creates task instance variable
      creates empty result hash

Finished in 0.08204 seconds (files took 0.50083 seconds to load)
36 examples, 0 failures
```
