### PR TITLE
Feature/ngui cluster filter

### DIFF
--- a/coopr-ngui/app/features/clusters/controllers/list-ctrl.js
+++ b/coopr-ngui/app/features/clusters/controllers/list-ctrl.js
@@ -10,11 +10,12 @@ function ($stateParams, $scope, $filter, $timeout, moment, myApi, CrudListBase) 
   var timeoutPromise,
       filterFilter = $filter('filter');
 
-  if($stateParams.status) {
-    console.log($stateParams);
-    $scope.list = myApi.Cluster.query($stateParams, updatePending);
+  if($stateParams.status === 'terminated') {
+    myApi.Cluster.query($stateParams, function (list) {
+      $scope.list = list;
+    });
   }
-  else { // we can re-use the "list" that comes from SubnavCtrl
+  else { // we can re-use the list that comes from SubnavCtrl
     $scope.$watchCollection('list', updatePending);
   }
 
@@ -28,7 +29,7 @@ function ($stateParams, $scope, $filter, $timeout, moment, myApi, CrudListBase) 
     if(filterFilter($scope.list, {status:'pending'}).length) {
       timeoutPromise = $timeout(function () {
 
-        myApi.Cluster.query($stateParams, function (list) {
+        myApi.Cluster.query(function (list) {
           // $scope.list = list works, but then we lose the animation of progress bars
           // instead we only modify the properties that interest us
           angular.forEach($scope.list, function (cluster) {

--- a/coopr-ngui/app/features/clusters/list.html
+++ b/coopr-ngui/app/features/clusters/list.html
@@ -58,7 +58,7 @@
 
 <div ng-hide="(list.$promise && !list.$resolved) || list.length" class="well text-center">
 
-  <p>You don't have any clusters!</p>
+  <p>No clusters to display in this view!</p>
   <p><a class="btn btn-primary" role="button" ui-sref="clusters.create">
     Create a cluster
   </a></p>
@@ -66,12 +66,18 @@
 </div>
 
 
-<!-- <div class="text-center am-fade-and-slide-top" ng-show="togglerVisible">
-  <hr />
-  <button type="button" class="btn btn-default btn-xs"
-      ng-model="filterIsOff"
-      bs-checkbox>
-    <span class="fa fa-ellipsis-v fa-fw"></span>
-    show all clusters
-  </button>
-</div> -->
+<div class="text-center small">
+
+  <a ng-hide="$stateParams.status === 'terminated'"
+     ui-sref="clusters.list({status: 'terminated'})"
+     ui-sref-opts="{reload: true}">
+    view terminated clusters
+  </a>
+
+  <a ng-hide="$stateParams.status !== 'terminated'"
+     ui-sref="clusters.list({status:null})"
+     ui-sref-opts="{reload: true}">
+    view active clusters
+  </a>
+
+</div>

--- a/coopr-ngui/app/features/clusters/list.html
+++ b/coopr-ngui/app/features/clusters/list.html
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    <tr ng-repeat="item in list | filter:(filterIsOff?null:isActive) | orderBy:sortable.predicate:sortable.reverse">
+    <tr ng-repeat="item in list | orderBy:sortable.predicate:sortable.reverse">
 
       <td><a ui-sref="^.detail({id: item.id})">{{item.name}}</a></td>
 
@@ -66,7 +66,7 @@
 </div>
 
 
-<div class="text-center am-fade-and-slide-top" ng-show="togglerVisible">
+<!-- <div class="text-center am-fade-and-slide-top" ng-show="togglerVisible">
   <hr />
   <button type="button" class="btn btn-default btn-xs"
       ng-model="filterIsOff"
@@ -74,4 +74,4 @@
     <span class="fa fa-ellipsis-v fa-fw"></span>
     show all clusters
   </button>
-</div>
+</div> -->

--- a/coopr-ngui/app/features/clusters/routes.js
+++ b/coopr-ngui/app/features/clusters/routes.js
@@ -4,6 +4,9 @@ angular.module(PKG.name+'.feature.clusters')
     var crud = CRUD_STATE_HELP.mkState,
         abstractSubnav = CRUD_STATE_HELP.abstractSubnav;
 
+
+    var clusterListState = crud('Cluster', 'list', 'ClusterListCtrl');
+
     /**
      * State Configurations
      */
@@ -17,7 +20,9 @@ angular.module(PKG.name+'.feature.clusters')
       .state(abstractSubnav('Cluster', {
         authorizedRoles: MYAUTH_ROLE.all
       }))
-        .state(crud('Cluster', 'list', 'ClusterListCtrl'))
+        .state(angular.extend(clusterListState, {
+          url: clusterListState.url + '?status'
+        }))
         .state(crud('Cluster', 'edit', 'ClusterFormCtrl', { title: 'Reconfigure cluster' }))
         .state(crud('Cluster', 'create', 'ClusterFormCtrl', { title: 'Create a cluster' }))
         .state(crud('Cluster', 'detail', 'ClusterDetailCtrl'))
@@ -26,6 +31,5 @@ angular.module(PKG.name+'.feature.clusters')
           })
 
       ;
-
 
   });

--- a/coopr-ngui/app/features/crud/controllers/subnav-ctrl.js
+++ b/coopr-ngui/app/features/crud/controllers/subnav-ctrl.js
@@ -15,22 +15,14 @@ function ($scope, $state, myApi) {
   /* ----------------------------------------------------------------------- */
 
   function fetchSubnavList () {
+
     $scope.subnavList = myApi[modelName].query(function (list) {
-      $scope.dropdown = list
-        .filter(function (item) {
-          switch (modelName) {
-            case 'Cluster':
-              return item.status!=='terminated';
-            default:
-              return true;
-          }
-        })
-        .map(function (item) {
-          return {
-            text: item.name,
-            href: $state.href($state.get(path+'.detail') || $state.get(path+'.edit'), item)
-          };
-        });
+      $scope.dropdown = list.map(function (item) {
+        return {
+          text: item.name,
+          href: $state.href($state.get(path+'.detail') || $state.get(path+'.edit'), item)
+        };
+      });
     });
   }
 

--- a/coopr-ngui/app/services/api/clusters.js
+++ b/coopr-ngui/app/services/api/clusters.js
@@ -1,11 +1,16 @@
-angular.module(PKG.name+'.services').factory('myApi_clusters', 
+angular.module(PKG.name+'.services').factory('myApi_clusters',
 function ($resource, myApiPrefix) {
 
   return {
 
     Cluster: $resource(myApiPrefix + 'clusters/:id',
       { id: '@id' },
-      { 
+      {
+        query: {
+          method: 'GET',
+          isArray: true,
+          params: { status: 'pending,active,incomplete,inconsistent' }
+        },
         getStatus: {
           method: 'GET',
           url: myApiPrefix + 'clusters/:id/status'
@@ -52,7 +57,7 @@ function ($resource, myApiPrefix) {
 
     ClusterService: $resource(myApiPrefix + 'clusters/:clusterId/services/:name',
       { name: '@name' },
-      { 
+      {
         start: {
           method: 'POST',
           url: myApiPrefix + 'clusters/:clusterId/services/:name/start'

--- a/coopr-ngui/test/unit/services/api-test.js
+++ b/coopr-ngui/test/unit/services/api-test.js
@@ -38,7 +38,7 @@ describe('api resources', function() {
       it('testing query()', function() {
         $httpBackend.expectGET(/v2\/clusters$/).respond([{foo:'bar'}]);
 
-        var list = myApi.Cluster.query();
+        var list = myApi.Cluster.query({status:null});
         $httpBackend.flush();
         expect(list[0].foo).toEqual('bar');
       });
@@ -57,7 +57,7 @@ describe('api resources', function() {
           return headers['Authorization'] === MY_CONFIG.authorization;
         }).respond(201, '');
 
-        myApi.Cluster.query();
+        myApi.Cluster.query({status:null});
         $httpBackend.flush();
       });
 
@@ -66,7 +66,7 @@ describe('api resources', function() {
           return !!headers['X-Requested-With'];
         }).respond(201, '');
 
-        myApi.Cluster.query();
+        myApi.Cluster.query({status:null});
         $httpBackend.flush();
       });
 
@@ -76,7 +76,7 @@ describe('api resources', function() {
         }).respond(201, '');
 
         myAuth.currentUser = {username:'test'};
-        myApi.Cluster.query();
+        myApi.Cluster.query({status:null});
         $httpBackend.flush();
         myAuth.currentUser = null;
       });


### PR DESCRIPTION
https://issues.cask.co/browse/COOPR-423

use API's `status` query parameter instead of fetching all clusters and filtering terminated ones on client side.
