### PR TITLE
Load plugins from additional possible plugin directories

### DIFF
--- a/coopr-provisioner/.rubocop_todo.yml
+++ b/coopr-provisioner/.rubocop_todo.yml
@@ -25,7 +25,7 @@ Lint/UselessAssignment:
 
 # Offense count: 28
 Metrics/AbcSize:
-  Max: 89
+  Max: 96
 
 # Offense count: 5
 # Configuration parameters: CountComments.
@@ -44,7 +44,7 @@ Metrics/LineLength:
 # Offense count: 36
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 49
+  Max: 51
 
 # Offense count: 8
 Metrics/PerceivedComplexity:

--- a/coopr-provisioner/worker/pluginmanager.rb
+++ b/coopr-provisioner/worker/pluginmanager.rb
@@ -40,8 +40,11 @@ class PluginManager
 
   # scan plugins directory for json plugin definitions, load plugins 
   def scan_plugins
-    # enforces directory structure from top-level: ./plugins/['providers']/[plugin-name]/*.json
-    Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*/*.json"].each do |jsonfile| 
+    # Allow both the old and new directory layouts and tenant-specific workdir plugins
+    # old: ./plugins/['providers']/[plugin-name]/*.json new: ./plugins/[plugin-name]/*.json
+    (Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*/*.json"] +
+     Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*.json"] +
+     Dir["#{@plugin_env[:work_dir]}/plugins/*/*.json"]).each do |jsonfile|
       begin
         log.debug "pluginmanager scanning #{jsonfile}"
         jsondata =  JSON.parse( IO.read(jsonfile) )

--- a/coopr-provisioner/worker/pluginmanager.rb
+++ b/coopr-provisioner/worker/pluginmanager.rb
@@ -40,11 +40,13 @@ class PluginManager
 
   # scan plugins directory for json plugin definitions, load plugins 
   def scan_plugins
-    # Allow both the old and new directory layouts and tenant-specific workdir plugins
+    # Allow both the old and new directory layouts
     # old: ./plugins/['providers']/[plugin-name]/*.json new: ./plugins/[plugin-name]/*.json
     (Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*/*.json"] +
-     Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*.json"] +
-     Dir["#{@plugin_env[:work_dir]}/plugins/*/*.json"]).each do |jsonfile|
+     Dir["#{File.expand_path(File.dirname(__FILE__))}/plugins/*/*.json"] # +
+    # Add this back once we figure out how to pass the work_dir to PluginManager
+    # Dir["#{@plugin_env[:work_dir]}/plugins/*/*.json"]
+    ).each do |jsonfile|
       begin
         log.debug "pluginmanager scanning #{jsonfile}"
         jsondata =  JSON.parse( IO.read(jsonfile) )


### PR DESCRIPTION
This allows for loading plugins from one of two locations:
- ${COOPR_HOME}/provisioner/worker/plugins/(automators|providers)/[plugin-name]/*.json
- ${COOPR_HOME}/provisioner/worker/plugins/[plugin-name]/*.json
