### PR TITLE
provide a way to leave iptables alone

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/default.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/default.rb
@@ -18,7 +18,11 @@
 #
 
 if node.key?('coopr_firewall')
-  include_recipe 'coopr_firewall::iptables'
+  if node['coopr_firewall'].key?('unmanaged') && node['coopr_firewall']['unmanaged'].to_s == 'true'
+    Chef::Log.info("Not managing host firewall per node['coopr_firewall']['unmanaged'] attribute")
+  else
+    include_recipe 'coopr_firewall::iptables'
+  end
 else
   include_recipe 'coopr_firewall::disable'
 end


### PR DESCRIPTION
Check an attribute before doing anything with iptables.  Useful for cases where you want to leave iptables alone, not disable it.  No changes to default behavior.
