### PR TITLE
Run register in foreground

### DIFF
--- a/coopr-provisioner/bin/provisioner.sh
+++ b/coopr-provisioner/bin/provisioner.sh
@@ -53,7 +53,7 @@ start ( ) {
 register ( ) {
   echo "Registering provisioner plugins with configured server"
   nice -1 ${COOPR_RUBY} ${PROVISIONER_PATH}/bin/provisioner ${PROVISIONER_CONF_OPT} --register \
-    >> ${COOPR_LOG_DIR}/${APP_NAME}.log 2>&1 &
+    >> ${COOPR_LOG_DIR}/${APP_NAME}.log 2>&1
 }
 
 stop ( ) {

--- a/coopr-provisioner/bin/setup.sh
+++ b/coopr-provisioner/bin/setup.sh
@@ -7,14 +7,9 @@ export COOPR_API_USER=${COOPR_API_USER:-admin}
 export COOPR_API_KEY=${COOPR_API_KEY:-1234567890abcdef}
 export COOPR_TENANT=${COOPR_TENANT:-superadmin}
 export COOPR_HOME=${COOPR_HOME:-/opt/coopr}
-export COOPR_RUBY=${COOPR_RUBY:-"${COOPR_HOME}/provisioner/embedded/bin/ruby"}
+export COOPR_RUBY=${COOPR_RUBY:-${COOPR_HOME}/provisioner/embedded/bin/ruby}
 
 export COOPR_PROVISIONER_PLUGIN_DIR=${COOPR_HOME}/provisioner/worker/plugins
-
-# TODO: steps
-# - register
-# - loop through upload scripts
-# - sync
 
 wait_for_plugin_registration () {
   RETRIES=0


### PR DESCRIPTION
Otherwise, the script will not exit with the correct exit code on a registration failure.
