### PR TITLE
Use JAVACMD rather than path-default java to check Java version

### DIFF
--- a/coopr-standalone/bin/coopr.sh
+++ b/coopr-standalone/bin/coopr.sh
@@ -99,7 +99,7 @@ location of your Java installation."
 fi
 
 # java version check
-JAVA_VERSION=`java -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
+JAVA_VERSION=`${JAVACMD} -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
 if [ ${JAVA_VERSION} -ne 6 ] && [ ${JAVA_VERSION} -ne 7 ]; then
   die "ERROR: Java version not supported
 Please install Java 6 or 7 - other versions of Java are not yet supported."


### PR DESCRIPTION
Copy caskdata/cdap#741 to use JAVACMD... thanks @sumitsu
