### PR TITLE
Feature/rm cors

### DIFF
--- a/coopr-ui/app/services/api.js
+++ b/coopr-ui/app/services/api.js
@@ -1,28 +1,10 @@
-/**
- * myApi
- * wraps all calls to the REST API
- * @return {Object} with one property xxxx per myApi_xxxx file 
- */
-
 var module = angular.module(PKG.name+'.services');
 
-module.factory('myApiPrefix', function myApiPrefixFactory ($location, MY_CONFIG) {
+module.value('myApiVersion', 2);
 
-  // to work with CORS proxy, we expect that the URI will include a port
-  //  ... first we need to remove the protocol from the URI 
-  var restPath = MY_CONFIG.COOPR_SERVER_URI.replace(/^(https?:\/\/)?/i, '');
-  if(restPath.substr(-1)!=='/') {
-    restPath += '/'; // then we ensure it ends with a slash
-  }
-  restPath += 'v2/'; // and add the version
-
-  /* end result should look something like:
-
-       http :// host.foo.com : 8081 / otherhost.foo.com:55054/v2/
-  */
-  return $location.protocol() + '://' + $location.host() + 
-            ':' + MY_CONFIG.COOPR_CORS_PORT + '/' + restPath;
-            
+module.factory('myApiPrefix', function myApiPrefixFactory ($location, myApiVersion) {
+  return $location.protocol() + '://' + $location.host() +
+            ':' + $location.port() + '/proxy/v' + myApiVersion + '/';
 });
 
 
@@ -31,6 +13,11 @@ module.constant('MYAPI_EVENT', {
 });
 
 
+/**
+ * myApi
+ * wraps all calls to the REST API
+ * @return {Object} with one property xxxx per myApi_xxxx file
+ */
 module.factory('myApi', function(
     myApi_clusters,
     myApi_hardwaretypes,
@@ -43,7 +30,7 @@ module.factory('myApi', function(
     myApi_importexport
   ){
 
-  return angular.extend({}, 
+  return angular.extend({},
     myApi_clusters,
     myApi_hardwaretypes,
     myApi_imagetypes,

--- a/coopr-ui/package.json
+++ b/coopr-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coopr-ui",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Front-end for Coopr",
   "repository": {
     "type": "git",
@@ -42,7 +42,6 @@
     "merge-stream": "^0.1.5"
   },
   "dependencies": {
-    "cors-anywhere": "^0.2.0",
     "express": "^4.9.7",
     "finalhandler": "^0.3.0",
     "morgan": "^1.3.1",

--- a/coopr-ui/package.json
+++ b/coopr-ui/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "express": "^4.9.7",
     "finalhandler": "^0.3.0",
+    "http-proxy": "^1.7.1",
     "morgan": "^1.3.1",
     "serve-favicon": "^2.1.5"
   }

--- a/coopr-ui/server.js
+++ b/coopr-ui/server.js
@@ -11,8 +11,7 @@ var pkg = require('./package.json'),
     https = require('https'),
     express = require('express'),
     finalhandler = require('finalhandler'),
-    serveFavicon = require('serve-favicon'),
-    corsAnywhere = require('cors-anywhere');
+    serveFavicon = require('serve-favicon');
 
 var COOPR_HOME = process.env.COOPR_HOME || (__dirname + '/../'),
     COOPR_SSL = ('true' === process.env.COOPR_SSL),
@@ -22,10 +21,7 @@ var COOPR_HOME = process.env.COOPR_HOME || (__dirname + '/../'),
     ),
     COOPR_UI_KEY_FILE = process.env.COOPR_UI_KEY_FILE || COOPR_HOME + 'cert/server.key',
     COOPR_UI_CERT_FILE = process.env.COOPR_UI_CERT_FILE || COOPR_HOME + 'cert/server.crt',
-    COOPR_CORS_PORT = parseInt(process.env.COOPR_CORS_PORT || 8081, 10),
     COOPR_SERVER_URI = process.env.COOPR_SERVER_URI || 'http://127.0.0.1:55054';
-
-COOPR_SERVER_URI = COOPR_SERVER_URI.replace('/localhost:', '/127.0.0.1:');
 
 var color = {
         hilite: function (v) {
@@ -45,14 +41,9 @@ morgan.token('cooprcred', function (req, res) {
 });
 
 var httpLabel = color.green('http'),
-    corsLabel = color.pink('cors'),
     httpStaticLogger = morgan(httpLabel + ' :method :url :status'),
     httpIndexLogger = morgan(httpLabel + ' :method ' + color.hilite(':url') + ' :status'),
-    corsLogger = morgan(corsLabel + ' :method :url :cooprcred :status', {
-        skip: function (req, res) {
-            return req.method === 'OPTIONS'
-        }
-    });
+    proxyLogger = morgan(color.pink('proxy') + ' :method :url :cooprcred :status');
 
 console.log(color.hilite(pkg.name) + ' v' + pkg.version + ' starting up...');
 
@@ -71,7 +62,6 @@ app.get('/config.js', function (req, res) {
         // the following will be available in angular via the "MY_CONFIG" injectable
 
         COOPR_SERVER_URI: COOPR_SERVER_URI,
-        COOPR_CORS_PORT: COOPR_CORS_PORT,
         authorization: req.headers.authorization
 
     });
@@ -130,16 +120,3 @@ server.listen(COOPR_UI_PORT, null, null, function () {
 });
 
 
-/**
- * CORS proxy
- */
-corsAnywhere.createServer({
-    requireHeader: ['x-requested-with'],
-    removeHeaders: ['cookie', 'cookie2']
-})
-    .on('request', function (req, res) {
-        corsLogger(req, res, function noop() {});
-    })
-    .listen(COOPR_CORS_PORT, '0.0.0.0', function () {
-        console.info(corsLabel + ' listening on port %s', COOPR_CORS_PORT);
-    });

--- a/coopr-ui/server.js
+++ b/coopr-ui/server.js
@@ -1,17 +1,9 @@
 /**
- * Spins up two web servers
- *   - http-server sends the static assets in dist and handles the /config.json endpoint
- *   - cors-proxy adds the necessary headers for xdomain access to the REST API
+ * Spins up a web server which will:
+ *   - send the static assets in dist
+ *   - handles the /config.json endpoint
+ *   - implement proxy at /proxy endpoint
  */
-
-var pkg = require('./package.json'),
-    fs = require('fs'),
-    morgan = require('morgan'),
-    http = require('http'),
-    https = require('https'),
-    express = require('express'),
-    finalhandler = require('finalhandler'),
-    serveFavicon = require('serve-favicon');
 
 var COOPR_HOME = process.env.COOPR_HOME || (__dirname + '/../'),
     COOPR_SSL = ('true' === process.env.COOPR_SSL),
@@ -23,7 +15,18 @@ var COOPR_HOME = process.env.COOPR_HOME || (__dirname + '/../'),
     COOPR_UI_CERT_FILE = process.env.COOPR_UI_CERT_FILE || COOPR_HOME + 'cert/server.crt',
     COOPR_SERVER_URI = process.env.COOPR_SERVER_URI || 'http://127.0.0.1:55054';
 
-var color = {
+var pkg = require('./package.json'),
+    fs = require('fs'),
+    morgan = require('morgan'),
+    http = require('http'),
+    https = require('https'),
+    proxy = require('http-proxy').createProxyServer({
+      target: COOPR_SERVER_URI
+    }),
+    express = require('express'),
+    finalhandler = require('finalhandler'),
+    serveFavicon = require('serve-favicon'),
+    color = {
         hilite: function (v) {
             return '\x1B[7m' + v + '\x1B[27m';
         },
@@ -43,7 +46,7 @@ morgan.token('cooprcred', function (req, res) {
 var httpLabel = color.green('http'),
     httpStaticLogger = morgan(httpLabel + ' :method :url :status'),
     httpIndexLogger = morgan(httpLabel + ' :method ' + color.hilite(':url') + ' :status'),
-    proxyLogger = morgan(color.pink('proxy') + ' :method :url :cooprcred :status');
+    httpProxyLogger = morgan(color.pink('prox') + ' :method :url :cooprcred :status');
 
 console.log(color.hilite(pkg.name) + ' v' + pkg.version + ' starting up...');
 
@@ -61,7 +64,6 @@ app.get('/config.js', function (req, res) {
     var data = JSON.stringify({
         // the following will be available in angular via the "MY_CONFIG" injectable
 
-        COOPR_SERVER_URI: COOPR_SERVER_URI,
         authorization: req.headers.authorization
 
     });
@@ -91,6 +93,19 @@ app.get('/robots.txt', [
         res.send('User-agent: *\nDisallow: /');
     }
 ]);
+
+
+// proxy requests to the backend
+app.all('/proxy/*', [
+    httpProxyLogger,
+    function (req, res) {
+        req.url = req.url.substr(6);
+        proxy.web(req, res);
+    }
+]);
+
+
+
 
 // any other path, serve index.html
 app.all('*', [

--- a/coopr-ui/test/config.js
+++ b/coopr-ui/test/config.js
@@ -3,5 +3,5 @@ window.PKG = {
 };
 
 angular.module("coopr-ui.config", []).constant("MY_CONFIG", {
-  "autorization": "respect my authoritah"
+  "authorization": "respect my authoritah"
 });

--- a/coopr-ui/test/config.js
+++ b/coopr-ui/test/config.js
@@ -4,6 +4,5 @@ window.PKG = {
 
 angular.module("coopr-ui.config", []).constant("MY_CONFIG", {
   "COOPR_SERVER_URI": "http://127.0.0.1:55054/v2/",
-  "COOPR_CORS_PORT": 8081,
   "autorization": "respect my authoritah"
 });

--- a/coopr-ui/test/config.js
+++ b/coopr-ui/test/config.js
@@ -3,6 +3,5 @@ window.PKG = {
 };
 
 angular.module("coopr-ui.config", []).constant("MY_CONFIG", {
-  "COOPR_SERVER_URI": "http://127.0.0.1:55054/v2/",
   "autorization": "respect my authoritah"
 });


### PR DESCRIPTION
removes CORS, replaces with a `/proxy/` path.

client has no need for knowledge of COOPR_SERVER_URI anymore.

see https://issues.cask.co/browse/COOPR-556 
