### PR TITLE
Ship profile.d script for packages

### DIFF
--- a/coopr-cli/distribution/etc/profile.d/coopr-cli.sh
+++ b/coopr-cli/distribution/etc/profile.d/coopr-cli.sh
@@ -1,0 +1,1 @@
+export PATH=$PATH:/opt/coopr/cli/bin


### PR DESCRIPTION
This will set the PATH for using `coopr-cli.sh` from anywhere on the system.
