### PR TITLE
Updated netty-http and common to release versions 0.7.0 and 0.1.0 respectively.

### DIFF
--- a/coopr-cli/pom.xml
+++ b/coopr-cli/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>co.cask.common</groupId>
       <artifactId>common-cli</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>jline</groupId>

--- a/coopr-integration-testing/pom.xml
+++ b/coopr-integration-testing/pom.xml
@@ -66,6 +66,12 @@
           <version>${project.parent.version}</version>
           <type>test-jar</type>
           <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>co.cask.cdap</groupId>
+              <artifactId>cdap-security</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>

--- a/coopr-integration-testing/pom.xml
+++ b/coopr-integration-testing/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>co.cask</groupId>
             <artifactId>coopr</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/coopr-rest-client/pom.xml
+++ b/coopr-rest-client/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
 
   <properties>
     <http.client.version>4.3.3</http.client.version>
-    <cask.common.version>0.1.0-SNAPSHOT</cask.common.version>
+    <cask.common.version>0.1.0</cask.common.version>
   </properties>
 
   <dependencies>

--- a/coopr-rest-client/pom.xml
+++ b/coopr-rest-client/pom.xml
@@ -38,7 +38,6 @@ limitations under the License.
     <dependency>
       <groupId>co.cask</groupId>
       <artifactId>coopr</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.common</groupId>

--- a/coopr-rest-client/pom.xml
+++ b/coopr-rest-client/pom.xml
@@ -52,6 +52,12 @@ limitations under the License.
       <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>co.cask.cdap</groupId>
+          <artifactId>cdap-security</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/coopr-server/pom.xml
+++ b/coopr-server/pom.xml
@@ -71,6 +71,16 @@
           <groupId>co.cask.cdap</groupId>
           <artifactId>cdap-security</artifactId>
           <version>2.6.0-SNAPSHOT</version>
+          <exclusions>
+            <exclusion>
+              <groupId>co.cask.common</groupId>
+              <artifactId>common-http</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>co.cask.common</groupId>
+              <artifactId>common-io</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
     </dependencies>
 

--- a/coopr-server/pom.xml
+++ b/coopr-server/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>co.cask.http</groupId>
             <artifactId>netty-http</artifactId>
-            <version>0.7.0-SNAPSHOT</version>
+            <version>0.7.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,22 @@
         </dependency>
     </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>co.cask</groupId>
+        <artifactId>coopr</artifactId>
+        <version>${project.parent.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>co.cask.cdap</groupId>
+            <artifactId>cdap-security</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
The netty-http and common dependencies of the COOPR have been updated to 0.7.0 and 0.1.0 versions respectively.
