### PR TITLE
Support for adding users

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -30,5 +30,10 @@ end
   include_recipe "coopr_#{cb}::default"
 end
 
-# ensure user ulimits are enabled 
+# Ensure user ulimits are enabled
 include_recipe 'ulimit::default'
+
+# Add users in the sysadmins group and give them sudo access
+%w(chef-solo-search sudo users).each do |cb|
+  include_recipe cb unless node['base'].key?("no_#{cb}") && node['base']["no_#{cb}"].to_s == 'true'
+end


### PR DESCRIPTION
This gives Coopr users the ability to provide a `users` data bag to the `users` cookbook. Any user in the `sysadmin` group will get added to the system. This is the same group that the `sudo` cookbook uses, so we are including that, too. We need `chef-solo-search` for the `users` cookbook to find the data bag items.
