### PR TITLE
Allow a way to disable the base cookbooks

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -27,7 +27,7 @@ end
 
 # We always run our dns, firewall, and hosts cookbooks
 %w(dns firewall hosts).each do |cb|
-  include_recipe "coopr_#{cb}::default"
+  include_recipe "coopr_#{cb}::default" unless node['base'].key?("no_#{cb}") && node['base']["no_#{cb}"].to_s == 'true'
 end
 
 # ensure user ulimits are enabled 


### PR DESCRIPTION
Disable the built-in cookbooks dns, firewall, and hosts by settings `base['no_dns']`, `base['no_firewall']`, and `base['no_hosts']`, respectively.

**WARNING** Disabling these services may cause your cluster to fail
