### PR TITLE
COOPR-651 Update netty-http to 0.8.0

### DIFF
--- a/coopr-server/pom.xml
+++ b/coopr-server/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>co.cask.http</groupId>
             <artifactId>netty-http</artifactId>
-            <version>0.7.0</version>
+            <version>0.8.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is a prerequisite to COOPR-652
