### PR TITLE
[coopr-648] dropdown control hides in "Service Set" block in case if there are no available actions.

### DIFF
--- a/coopr-ui/app/directives/thingpicker/servicepicker.js
+++ b/coopr-ui/app/directives/thingpicker/servicepicker.js
@@ -105,7 +105,12 @@ function myServicePickerDirective (MYSERVICEPICKER_EVENT) {
               });            
             }
 
-            out[name] = dd;
+            /**
+             * As long empty array is a valid object and angular expressions are not able to check for array length,
+             * dropdown control would be displayed.
+             * null would help to serve this expression in thingpicker template: ng-if="actionDropdowns[name]".
+             */
+            out[name] = dd.length ? dd : null;
 
           }
           return out;


### PR DESCRIPTION
According to https://issues.cask.co/browse/COOPR-648
