### PR TITLE
update fog from 1.21.0 to 1.26.0

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fog', '~> 1.21.0'
+gem 'fog', '~> 1.26.0'
 gem 'net-ssh'
 gem 'google-api-client', '~> 0.6', '>= 0.6.2'
 

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
@@ -23,7 +23,7 @@ require_relative 'fog_provider/joyent'
 require_relative 'fog_provider/openstack'
 require_relative 'fog_provider/rackspace'
 
-gem 'fog', '~> 1.21.0'
+gem 'fog', '~> 1.26.0'
 
 require 'fog'
 require 'ipaddr'

--- a/coopr-standalone/README.md
+++ b/coopr-standalone/README.md
@@ -13,7 +13,7 @@ mvn clean package assembly:single -DskipTests
 
 ## Install
 ```
-sudo gem install fog --version 1.21.0
+sudo gem install fog --version 1.26.0
 sudo gem install sinatra --version 1.4.5
 sudo gem install thin --version 1.6.2
 sudo gem install rest_client --version 1.7.3


### PR DESCRIPTION
This will ensure we have the fog 1.26.x gem installed, where x>=0.
