### PR TITLE
Allow bower to run as root, necessary for Docker builds

### DIFF
--- a/coopr-ui/package.json
+++ b/coopr-ui/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node ./server.js",
     "backend": "COOPR_USE_DUMMY_PROVISIONER=true COOPR_DISABLE_UI=true ../coopr-standalone/target/coopr-0.9.9-SNAPSHOT-standalone/bin/coopr.sh",
-    "prebuild": "npm install && ./node_modules/bower/bin/bower update --config.interactive=false",
+    "prebuild": "npm install && ./node_modules/bower/bin/bower update --config.interactive=false --allow-root",
     "build": "node ./node_modules/gulp/bin/gulp.js build",
     "test": "node ./node_modules/karma/bin/karma start test/karma-conf.js",
     "test-single-run": "node ./node_modules/karma/bin/karma start test/karma-conf.js --no-auto-watch --single-run"


### PR DESCRIPTION
This should resolve the following error when building UI from a Docker context:

```
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option

npm ERR! coopr-ui@1.4.0 prebuild: `npm install && ./node_modules/bower/bin/bower update --config.interactive=false`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the coopr-ui@1.4.0 prebuild script.
npm ERR! This is most likely a problem with the coopr-ui package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm install && ./node_modules/bower/bin/bower update --config.interactive=false
npm ERR! You can get their info via:
npm ERR!     npm owner ls coopr-ui
npm ERR! There is likely additional logging output above.
npm ERR! System Linux 3.17.2
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "run" "prebuild"
npm ERR! cwd /Build/coopr-ui
npm ERR! node -v v0.10.33
npm ERR! npm -v 1.4.28
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Build/coopr-ui/npm-debug.log
npm ERR! not ok code 0
[20:19:16] Using gulpfile /Build/coopr-ui/Gulpfile.js
[20:19:16] Starting 'js:lib'...
[20:19:16] 'js:lib' errored after 483 μs
[20:19:16] Error: Bower components directory does not exist at /Build/coopr-ui/bower_components
    at module.exports (/Build/coopr-ui/node_modules/main-bower-files/lib/index.js:48:15)
    at Gulp.gulp.task.JSON.stringify.name (/Build/coopr-ui/Gulpfile.js:97:8)
    at module.exports (/Build/coopr-ui/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Build/coopr-ui/node_modules/gulp/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Build/coopr-ui/node_modules/gulp/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/Build/coopr-ui/node_modules/gulp/node_modules/orchestrator/index.js:134:8)
    at /Build/coopr-ui/node_modules/gulp/bin/gulp.js:129:20
    at process._tickCallback (node.js:419:13)
    at Function.Module.runMain (module.js:499:11)
    at startup (node.js:119:16)
```
