### PR TITLE
COOPR-615: Enable kerberos login for zookeeper.

### DIFF
--- a/coopr-server/src/main/java/co/cask/coopr/runtime/ServerMain.java
+++ b/coopr-server/src/main/java/co/cask/coopr/runtime/ServerMain.java
@@ -131,7 +131,6 @@ public final class ServerMain extends DaemonMain {
       solverNumThreads = conf.getInt(Constants.SOLVER_NUM_THREADS);
     } catch (Exception e) {
       LOG.error("Exception initializing server", e);
-      System.exit(-1);
     }
   }
 

--- a/coopr-server/src/main/java/co/cask/coopr/runtime/ServerMain.java
+++ b/coopr-server/src/main/java/co/cask/coopr/runtime/ServerMain.java
@@ -19,6 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.security.guice.SecurityModules;
 import co.cask.cdap.security.server.ExternalAuthenticationServer;
 import co.cask.coopr.codec.json.guice.CodecModules;
@@ -80,6 +81,7 @@ public final class ServerMain extends DaemonMain {
   private InternalHandlerServer internalHandlerServer;
   private Scheduler scheduler;
   private Configuration conf;
+  private CConfiguration cConf;
   private int solverNumThreads;
   private ListeningExecutorService solverExecutorService;
   private ListeningExecutorService callbackExecutorService;
@@ -105,6 +107,17 @@ public final class ServerMain extends DaemonMain {
     try {
       conf = Configuration.create();
 
+      cConf = CConfiguration.create();
+      cConf.addResource("coopr-default.xml");
+      cConf.addResource("coopr-site.xml");
+
+      securityEnabled = conf.getBoolean(co.cask.cdap.common.conf.Constants.Security.ENABLED);
+
+      if (securityEnabled) {
+        // Enable Kerberos login
+        SecurityUtil.enableKerberosLogin(cConf);
+      }
+
       String zkQuorum = conf.get(Constants.ZOOKEEPER_QUORUM);
       if (zkQuorum == null) {
         String dataPath = conf.get(Constants.LOCAL_DATA_DIR) + "/zookeeper";
@@ -116,9 +129,9 @@ public final class ServerMain extends DaemonMain {
       }
 
       solverNumThreads = conf.getInt(Constants.SOLVER_NUM_THREADS);
-      securityEnabled = conf.getBoolean(co.cask.cdap.common.conf.Constants.Security.ENABLED);
     } catch (Exception e) {
       LOG.error("Exception initializing server", e);
+      System.exit(-1);
     }
   }
 
@@ -145,10 +158,6 @@ public final class ServerMain extends DaemonMain {
                                       .setDaemon(true)
                                       .build()));
 
-    CConfiguration cConfiguration = CConfiguration.create();
-    cConfiguration.addResource("coopr-default.xml");
-    cConfiguration.addResource("coopr-site.xml");
-
     try {
       // this is here instead of in init because when it runs with in-process zookeeper, the zk client service
       // cannot be created until the server is started (needs connection string)
@@ -165,7 +174,7 @@ public final class ServerMain extends DaemonMain {
         new IOModule(),
         new DiscoveryRuntimeModule().getStandaloneModules(),
         new SecurityModules().getStandaloneModules(),
-        new ConfigModule(cConfiguration)
+        new ConfigModule(cConf)
       );
 
       idService = injector.getInstance(IdService.class);


### PR DESCRIPTION
@jwang47 Added kerberos login to secure communications with ZooKeeper.

I have tested the fix locally and as result got next messages in ZooKeeper:
2014-12-18 18:39:33,649 [myid] - INFO  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxnFactory@197] - Accepted socket connection from /127.0.0.1:52630
Found key for zookeeper/example.com@EXAMPLE.COM(23)
Found key for zookeeper/example.com@EXAMPLE.COM(16)
Found key for zookeeper/example.com@EXAMPLE.COM(1)
2014-12-18 18:39:33,651 [myid] - INFO  [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:ZooKeeperServer@868] - Client attempting to establish new session at /127.0.0.1:52630
2014-12-18 18:39:33,662 [myid] - INFO  [SyncThread:0:ZooKeeperServer@617] - Established session 0x14a5e3c7ff40001 with negotiated timeout 40000 for client /127.0.0.1:52630

The cdap-security will be replaced by common-security, when this refactoring will done.
