### PR TITLE
Import cdap version 1.1.1

### DIFF
--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/.travis.yml
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/.travis.yml
@@ -1,10 +1,7 @@
 language: ruby
-
 rvm:
   - 1.9.3
-
-bundler_args: --jobs 7 --without docs
-
-install: bundle install --without integration
-
+cache: bundler
+sudo: false
+bundler_args: --jobs 7 --without docs integration
 script: bundle exec rake

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/Vagrantfile
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/Vagrantfile
@@ -22,7 +22,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     centos-6.5
     ubuntu-12.04
   ).each do |platform|
-
     config.vm.define platform do |c|
       c.vm.box       = "opscode-#{platform}"
       c.vm.box_url   = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_#{platform}_chef-provisionerless.box"

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/config_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/config_test.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::config' do
-
   include Helpers::CDAP
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/default_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/default_test.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::default' do
-
   include Helpers::CDAP
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/fullstack_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/fullstack_test.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::fullstack' do
-
   include Helpers::CDAP
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/gateway_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/gateway_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::gateway' do
-
   include Helpers::CDAP
 
   it 'verifies gateway installation' do
@@ -10,5 +9,4 @@ describe 'cdap::gateway' do
     file('/etc/init.d/cdap-gateway').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
     file('/etc/init.d/cdap-router').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/init_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/init_test.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::init' do
-
   include Helpers::CDAP
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/kafka_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/kafka_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::kafka' do
-
   include Helpers::CDAP
 
   it 'verifies kafka installation' do
@@ -9,5 +8,4 @@ describe 'cdap::kafka' do
     file('/opt/cdap/kafka/VERSION').must_exist.with(:owner, 'cdap').and(:group, 'cdap')
     file('/etc/init.d/cdap-kafka-server').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/master_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/master_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::master' do
-
   include Helpers::CDAP
 
   it 'verifies master installation' do
@@ -9,5 +8,4 @@ describe 'cdap::master' do
     file('/opt/cdap/master/VERSION').must_exist.with(:owner, 'cdap').and(:group, 'cdap')
     file('/etc/init.d/cdap-master').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/repo_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/repo_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::repo' do
-
   include Helpers::CDAP
 
   # Example spec tests can be found at http://git.io/Fahwsw
@@ -22,5 +21,4 @@ describe 'cdap::repo' do
       file('/etc/apt/sources.list.d/cask.list').must_include "#{node['cdap']['repo']['url']}"
     end
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/security_init_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/security_init_test.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::security_init' do
-
   include Helpers::CDAP
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/security_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/security_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::security' do
-
   include Helpers::CDAP
 
   it 'verifies security installation' do
@@ -9,5 +8,4 @@ describe 'cdap::security' do
     file('/opt/cdap/security/VERSION').must_exist.with(:owner, 'cdap').and(:group, 'cdap')
     file('/etc/init.d/cdap-auth-server').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/web_app_test.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/files/default/tests/minitest/web_app_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../support/helpers', __FILE__)
 
 describe 'cdap::web_app' do
-
   include Helpers::CDAP
 
   it 'verifies web-app installation' do
@@ -9,5 +8,4 @@ describe 'cdap::web_app' do
     file('/opt/cdap/web-app/VERSION').must_exist.with(:owner, 'cdap').and(:group, 'cdap')
     file('/etc/init.d/cdap-web-app').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
   end
-
 end

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.json
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.json
@@ -47,5 +47,5 @@
   "recipes": {
 
   },
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
 %w(apt hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/recipes/default.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/recipes/default.rb
@@ -55,6 +55,7 @@ file '/etc/profile.d/cdap_home.sh' do
 end
 
 package 'cdap' do
+  version node['cdap']['version']
   action :install
 end
 

--- a/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/recipes/master.rb
+++ b/coopr-provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/recipes/master.rb
@@ -19,6 +19,18 @@
 
 include_recipe 'cdap::default'
 
+pkgs = %w(cdap-hbase-compat-0.94 cdap-hbase-compat-0.96)
+if node['cdap']['version'].to_f >= 2.6 || node['cdap']['version'].split('.')[2].to_i >= 9000
+  pkgs += ['cdap-hbase-compat-0.98']
+end
+
+pkgs.each do |pkg|
+  package pkg do
+    version node['cdap']['version']
+    action :install
+  end
+end
+
 package 'cdap-master' do
   action :install
   version node['cdap']['version']


### PR DESCRIPTION
This relates to [COOK-15](https://issues.cask.co/browse/COOK-15) and fixes support for pre-release versions of CDAP 2.6 (2.5.9000+)

Since it is import-only, I will self-approve.
