### PR TITLE
Cleanup continuuity and invalid dash characters

### DIFF
--- a/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
@@ -43,12 +43,12 @@ public class PartialTemplateTest extends BaseTest {
   private static Account account;
 
   private static final Set<String> defaultsServices =
-    Sets.newHashSet("cdap­security", "mysql­server", "continuuity­sensu­monitoring", "bob", "hive-metastore-database",
+    Sets.newHashSet("cdap­security", "mysql­server", "sensu­monitoring", "bob", "hive-metastore-database",
                     "hive-metastore", "zookeeper­server", "cdap", "hive-server2", "ldap­internal");
   private static final Set<String> compatibilitiesHardwaretypes = Sets.newHashSet("standard­large", "standard-xlarge");
   private static final Set<String> compatibilitiesImagetypes = Sets.newHashSet("centos6", "ubuntu12");
   private static final Set<String> compatibilitiesServices =
-    Sets.newHashSet("mysql­server", "continuuity­sensu­monitoring", "kerberos­client", "zookeeper­server", "cdap",
+    Sets.newHashSet("mysql­server", "sensu­monitoring", "kerberos­client", "zookeeper­server", "cdap",
                     "ldap­internal");
   private static final Map<String, ServiceConstraint> serviceConstraints = Maps.newHashMap();
 
@@ -189,7 +189,7 @@ public class PartialTemplateTest extends BaseTest {
     Assert.assertEquals("rackspace", rt.getClusterDefaults().getProvider());
     Assert.assertEquals("standard­large", rt.getClusterDefaults().getHardwaretype());
     Assert.assertEquals("centos6", rt.getClusterDefaults().getImagetype());
-    Assert.assertEquals("dev.continuuity.net", rt.getClusterDefaults().getDnsSuffix());
+    Assert.assertEquals("example.com", rt.getClusterDefaults().getDnsSuffix());
 
     Assert.assertEquals(2, rt.getConstraints().getLayoutConstraint().getServicesThatMustCoexist().size());
     Assert.assertEquals(2, rt.getConstraints().getLayoutConstraint().getServicesThatMustNotCoexist().size());

--- a/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
@@ -43,12 +43,12 @@ public class PartialTemplateTest extends BaseTest {
   private static Account account;
 
   private static final Set<String> defaultsServices =
-    Sets.newHashSet("cdap­security", "mysql­server", "sensu­monitoring", "bob", "hive-metastore-database",
+    Sets.newHashSet("cdap­security", "mysql­server", "sensu-monitoring", "bob", "hive-metastore-database",
                     "hive-metastore", "zookeeper­server", "cdap", "hive-server2", "ldap­internal");
   private static final Set<String> compatibilitiesHardwaretypes = Sets.newHashSet("standard­large", "standard-xlarge");
   private static final Set<String> compatibilitiesImagetypes = Sets.newHashSet("centos6", "ubuntu12");
   private static final Set<String> compatibilitiesServices =
-    Sets.newHashSet("mysql­server", "sensu­monitoring", "kerberos­client", "zookeeper­server", "cdap",
+    Sets.newHashSet("mysql­server", "sensu-monitoring", "kerberos­client", "zookeeper­server", "cdap",
                     "ldap­internal");
   private static final Map<String, ServiceConstraint> serviceConstraints = Maps.newHashMap();
 

--- a/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
+++ b/coopr-server/src/test/java/co/cask/coopr/spec/template/PartialTemplateTest.java
@@ -43,13 +43,13 @@ public class PartialTemplateTest extends BaseTest {
   private static Account account;
 
   private static final Set<String> defaultsServices =
-    Sets.newHashSet("cdap­security", "mysql­server", "sensu-monitoring", "bob", "hive-metastore-database",
-                    "hive-metastore", "zookeeper­server", "cdap", "hive-server2", "ldap­internal");
-  private static final Set<String> compatibilitiesHardwaretypes = Sets.newHashSet("standard­large", "standard-xlarge");
+    Sets.newHashSet("cdap-security", "mysql-server", "sensu-monitoring", "bob", "hive-metastore-database",
+                    "hive-metastore", "zookeeper-server", "cdap", "hive-server2", "ldap-internal");
+  private static final Set<String> compatibilitiesHardwaretypes = Sets.newHashSet("standard-large", "standard-xlarge");
   private static final Set<String> compatibilitiesImagetypes = Sets.newHashSet("centos6", "ubuntu12");
   private static final Set<String> compatibilitiesServices =
-    Sets.newHashSet("mysql­server", "sensu-monitoring", "kerberos­client", "zookeeper­server", "cdap",
-                    "ldap­internal");
+    Sets.newHashSet("mysql-server", "sensu-monitoring", "kerberos-client", "zookeeper-server", "cdap",
+                    "ldap-internal");
   private static final Map<String, ServiceConstraint> serviceConstraints = Maps.newHashMap();
 
   private static final ClassLoader classLoader = PartialTemplateTest.class.getClassLoader();
@@ -148,8 +148,8 @@ public class PartialTemplateTest extends BaseTest {
 
     Assert.assertEquals("Configure Example, Inc. LDAP services", ldapInternal.getDescription());
     Assert.assertEquals(true, sensuInternal.isImmutable());
-    Assert.assertEquals("ldap­internal", ldapInternal.clusterDefaults.getServices().iterator().next());
-    Assert.assertEquals("ldap­internal", ldapInternal.compatibilities.getServices().iterator().next());
+    Assert.assertEquals("ldap-internal", ldapInternal.clusterDefaults.getServices().iterator().next());
+    Assert.assertEquals("ldap-internal", ldapInternal.compatibilities.getServices().iterator().next());
     Assert.assertNotNull(ldapInternal.clusterDefaults.getConfig().get("ldap"));
     Assert.assertEquals("ldap.wrong.com", ldapInternal.clusterDefaults.getConfig().get("ldap")
       .getAsJsonObject().get("endpoint").getAsString());
@@ -162,7 +162,7 @@ public class PartialTemplateTest extends BaseTest {
     Assert.assertEquals("LDAP-internal", cdapDistributedSecureHadoop.getIncludes().iterator().next().getName());
     Assert.assertEquals(3, cdapDistributedSecureHadoop.clusterDefaults.getServices().size());
     Assert.assertNotNull(cdapDistributedSecureHadoop.getClusterDefaults().getConfig().get("hive"));
-    Assert.assertEquals("kerberos­client",
+    Assert.assertEquals("kerberos-client",
                         cdapDistributedSecureHadoop.getCompatibilities().getServices().iterator().next());
   }
 
@@ -187,7 +187,7 @@ public class PartialTemplateTest extends BaseTest {
     Assert.assertEquals(defaultsServices, rt.getClusterDefaults().getServices());
     Assert.assertEquals(16, rt.getClusterDefaults().getConfig().entrySet().size());
     Assert.assertEquals("rackspace", rt.getClusterDefaults().getProvider());
-    Assert.assertEquals("standard­large", rt.getClusterDefaults().getHardwaretype());
+    Assert.assertEquals("standard-large", rt.getClusterDefaults().getHardwaretype());
     Assert.assertEquals("centos6", rt.getClusterDefaults().getImagetype());
     Assert.assertEquals("example.com", rt.getClusterDefaults().getDnsSuffix());
 

--- a/coopr-server/src/test/resources/partials/cdap-bad-json-format.json
+++ b/coopr-server/src/test/resources/partials/cdap-bad-json-format.json
@@ -5,7 +5,7 @@
     "immutable": "false",
     "defaults":
         [
-            "ldap­internal"
+            "ldap-internal"
         ],
         "config": {
             "ldap": {

--- a/coopr-server/src/test/resources/partials/cdap-distributed-insecure.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-insecure.json
@@ -17,7 +17,7 @@
         "provider": "google",
         "hardwaretype": "standard­large",
         "imagetype": "centos6",
-        "dnsSuffix": "dev.continuuity.net",
+        "dnsSuffix": "example.com",
         "config": {
             "mysql": {
                 "server_debian_password": "somedefaultpassword",

--- a/coopr-server/src/test/resources/partials/cdap-distributed-insecure.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-insecure.json
@@ -4,8 +4,8 @@
     "description": "Cask DAP (CDAP) and Hadoop cluster with single master",
     "defaults": {
         "services": [
-            "zookeeper­server",
-            "mysql­server",
+            "zookeeper-server",
+            "mysql-server",
             "cdap",
             {
                 "name": "bob",
@@ -15,7 +15,7 @@
             }
         ],
         "provider": "google",
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "dnsSuffix": "example.com",
         "config": {
@@ -40,7 +40,7 @@
     },
     "compatibility": {
         "hardwaretypes": [
-            "standard­large",
+            "standard-large",
             "standard-xlarge"
         ],
         "imagetypes": [
@@ -48,9 +48,9 @@
             "ubuntu12"
         ],
         "services": [
-            "zookeeper­server",
+            "zookeeper-server",
             "cdap",
-            "mysql­server"
+            "mysql-server"
         ]
     },
     "constraints": {

--- a/coopr-server/src/test/resources/partials/cdap-distributed-secure-hadoop.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-secure-hadoop.json
@@ -37,7 +37,7 @@
     },
     "compatibility": {
         "services": [
-            "kerberos­client"
+            "kerberos-client"
         ]
     }
 }

--- a/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-provider.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-provider.json
@@ -3,10 +3,10 @@
     "version": "1",
     "description": "Template without defaults provide",
     "defaults": {
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "services": [
-            "ldap­internal"
+            "ldap-internal"
         ],
         "config": {
             "security.enabled": "true"

--- a/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-services.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-services.json
@@ -6,7 +6,7 @@
         "provider": "google",
         "hardwaretype": "standard­large",
         "imagetype": "centos6",
-        "dnsSuffix": "dev.continuuity.net",
+        "dnsSuffix": "example.com",
         "config": {
             "security.enabled": "true"
         }

--- a/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-services.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed-without-defaults-services.json
@@ -4,7 +4,7 @@
     "description": "Template without defaults services",
     "defaults": {
         "provider": "google",
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "dnsSuffix": "example.com",
         "config": {

--- a/coopr-server/src/test/resources/partials/cdap-distributed.json
+++ b/coopr-server/src/test/resources/partials/cdap-distributed.json
@@ -12,7 +12,7 @@
     ],
     "defaults": {
         "services": [
-            "cdap­security"
+            "cdap-security"
         ],
         "config": {
             "security.enabled": "true",

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-parent.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-parent.json
@@ -7,7 +7,7 @@
     },
     "defaults": {
         "provider": "google",
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "dnsSuffix": "example.com",
         "config": {
@@ -15,7 +15,7 @@
                 "additional_client_attributes": {
                     "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.example.com"
+                "endpoint": "sensu-internal-server.example.com"
             }
         }
     }

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-parent.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-parent.json
@@ -9,13 +9,13 @@
         "provider": "google",
         "hardwaretype": "standard­large",
         "imagetype": "centos6",
-        "dnsSuffix": "dev.continuuity.net",
+        "dnsSuffix": "example.com",
         "config": {
             "sensu_wrapper": {
                 "additional_client_attributes": {
-                    "mail_to": "%cluster.owner%@cask.co"
+                    "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.cask.co"
+                "endpoint": "sensu­internal­server.example.com"
             }
         }
     }

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-partial.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-partial.json
@@ -11,13 +11,13 @@
         "provider": "google",
         "hardwaretype": "standard­large",
         "imagetype": "centos6",
-        "dnsSuffix": "dev.continuuity.net",
+        "dnsSuffix": "example.com",
         "config": {
             "sensu_wrapper": {
                 "additional_client_attributes": {
-                    "mail_to": "%cluster.owner%@cask.co"
+                    "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.cask.co"
+                "endpoint": "sensu­internal­server.example.com"
             }
         }
     }

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-partial.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted-overrides-partial.json
@@ -9,7 +9,7 @@
     ],
     "defaults": {
         "provider": "google",
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "dnsSuffix": "example.com",
         "config": {
@@ -17,7 +17,7 @@
                 "additional_client_attributes": {
                     "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.example.com"
+                "endpoint": "sensu-internal-server.example.com"
             }
         }
     }

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted.json
@@ -12,6 +12,6 @@
         "provider": "google",
         "hardwaretype": "standard­large",
         "imagetype": "centos6",
-        "dnsSuffix": "dev.continuuity.net"
+        "dnsSuffix": "example.com"
     }
 }

--- a/coopr-server/src/test/resources/partials/cdap-not-persisted.json
+++ b/coopr-server/src/test/resources/partials/cdap-not-persisted.json
@@ -10,7 +10,7 @@
     ],
     "defaults": {
         "provider": "google",
-        "hardwaretype": "standard­large",
+        "hardwaretype": "standard-large",
         "imagetype": "centos6",
         "dnsSuffix": "example.com"
     }

--- a/coopr-server/src/test/resources/partials/ldap-partial.json
+++ b/coopr-server/src/test/resources/partials/ldap-partial.json
@@ -5,7 +5,7 @@
     "immutable": "false",
     "defaults": {
         "services": [
-            "ldap­internal"
+            "ldap-internal"
         ],
         "config": {
             "ldap": {
@@ -15,7 +15,7 @@
     },
     "compatibility": {
         "services": [
-            "ldap­internal"
+            "ldap-internal"
         ]
     }
 }

--- a/coopr-server/src/test/resources/partials/partial-immutable-overrides.json
+++ b/coopr-server/src/test/resources/partials/partial-immutable-overrides.json
@@ -8,7 +8,7 @@
                 "additional_client_attributes": {
                     "mail_to": "%cluster.owner%@cask.co"
                 },
-                "endpoint": "sensu­internal­server.cask.co"
+                "endpoint": "sensu-internal-server.cask.co"
             }
         }
     }

--- a/coopr-server/src/test/resources/partials/sensu-partial.json
+++ b/coopr-server/src/test/resources/partials/sensu-partial.json
@@ -5,20 +5,20 @@
     "immutable": true,
     "defaults": {
         "services": [
-            "sensu­monitoring"
+            "sensu-monitoring"
         ],
         "config": {
             "sensu_wrapper": {
                 "additional_client_attributes": {
                     "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.example.com"
+                "endpoint": "sensu-internal-server.example.com"
             }
         }
     },
     "compatibility": {
         "services": [
-            "sensu­monitoring"
+            "sensu-monitoring"
         ]
     }
 }

--- a/coopr-server/src/test/resources/partials/sensu-partial.json
+++ b/coopr-server/src/test/resources/partials/sensu-partial.json
@@ -1,24 +1,24 @@
 {
     "name": "sensu-internal",
     "version": "1",
-    "description": "Configure Sensu clients to integrate with Cask internal monitoring infrastructure",
+    "description": "Configure Sensu clients to integrate with example internal monitoring infrastructure",
     "immutable": true,
     "defaults": {
         "services": [
-            "continuuity­sensu­monitoring"
+            "sensu­monitoring"
         ],
         "config": {
             "sensu_wrapper": {
                 "additional_client_attributes": {
-                    "mail_to": "%cluster.owner%@cask.co"
+                    "mail_to": "%cluster.owner%@example.com"
                 },
-                "endpoint": "sensu­internal­server.cask.co"
+                "endpoint": "sensu­internal­server.example.com"
             }
         }
     },
     "compatibility": {
         "services": [
-            "continuuity­sensu­monitoring"
+            "sensu­monitoring"
         ]
     }
 }

--- a/coopr-server/src/test/resources/partials/template-with-overrides-in-body.json
+++ b/coopr-server/src/test/resources/partials/template-with-overrides-in-body.json
@@ -10,7 +10,7 @@
                 "additional_client_attributes": {
                     "mail_to": "%cluster.owner%@cask.co"
                 },
-                "endpoint": "sensu­internal­server.cask.co"
+                "endpoint": "sensu-internal-server.cask.co"
             }
         }
     }


### PR DESCRIPTION
There are several mentions of `continuuity` in the new partials code. Removing this. Also, there's a **ton** of places where the '-' (dash) character is some other encoding. Fixing these...
