### PR TITLE
[coopr-647-tolltips] [COOPR-UI CreateCluster Page] templates list shows template label instead of template description; template description is shown in tooltip

### DIFF
--- a/coopr-ui/app/features/clusters/form.html
+++ b/coopr-ui/app/features/clusters/form.html
@@ -22,7 +22,7 @@
         ng-model="model.clusterTemplate"
         required>
           <option ng-repeat="ctpl in availableTemplates"
-            label="{{ ctpl.name }}"
+            ng-bind="ctpl.name"
             value="{{ ctpl.name }}"
             title="{{ ctpl.description }}"></option>
       </select>

--- a/coopr-ui/app/features/clusters/form.html
+++ b/coopr-ui/app/features/clusters/form.html
@@ -20,7 +20,11 @@
       <select id="inputClusterTemplate" name="template" class="form-control"
         ng-disabled="editing"
         ng-model="model.clusterTemplate"
-        ng-options="ctpl.name as ctpl.description for ctpl in availableTemplates" required>
+        required>
+          <option ng-repeat="ctpl in availableTemplates"
+            label="{{ ctpl.name }}"
+            value="{{ ctpl.name }}"
+            title="{{ ctpl.description }}"></option>
       </select>
     </div>
 


### PR DESCRIPTION
According to: https://issues.cask.co/browse/COOPR-647

Browser tooltips are used instead of bs-tooltip. Reasons:
1. bs-tooltip is not able to add tooltips for option tag. 
2. Browser places tooltips near the mouse pointer.
