### PR TITLE
COOPR-604: CLI: help command output should be more readable.

### DIFF
--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/AddServicesOnClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/AddServicesOnClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,6 @@ public class AddServicesOnClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Adds one or more services to a cluster";
+    return "Add one or more services to a cluster";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ConnectCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ConnectCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,6 @@ public class ConnectCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Connects to a Coopr instance";
+    return "Connect to a Coopr instance";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/CreateClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/CreateClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,6 @@ public class CreateClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Creates a cluster";
+    return "Create a cluster";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,6 @@ public class DeleteClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a cluster";
+    return "Delete a cluster";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteClusterTemplateCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteClusterTemplateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteClusterTemplateCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a cluster template";
+    return "Delete a cluster template";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteHardwareTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteHardwareTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteHardwareTypeCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a hardware type";
+    return "Delete a hardware type";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteImageTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteImageTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteImageTypeCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes an image type";
+    return "Delete an image type";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteProviderCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteProviderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteProviderCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a provider";
+    return "Delete a provider";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteServiceCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteServiceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteServiceCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a service";
+    return "Delete a service";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteTenantCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/DeleteTenantCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,6 @@ public class DeleteTenantCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Deletes a tenant";
+    return "Delete a tenant";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetAutomatorTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetAutomatorTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,11 @@ public class GetAutomatorTypeCommand implements Command {
 
   @Override
   public String getPattern() {
-    return String.format("get automatortype <%s>", AUTOMATOR_TYPE_ID);
+    return String.format("get automator type <%s>", AUTOMATOR_TYPE_ID);
   }
 
   @Override
   public String getDescription() {
-    return "Get automator type by id";
+    return "Get the automator type by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the cluster";
+    return "Get the cluster by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterConfigCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetClusterConfigCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the cluster config";
+    return "Get the cluster config by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterStatusCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterStatusCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetClusterStatusCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the cluster status";
+    return "Get the cluster status by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterTemplateCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetClusterTemplateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetClusterTemplateCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the cluster template";
+    return "Get the cluster template";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetHardwareTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetHardwareTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetHardwareTypeCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the hardware type";
+    return "Get the hardware type";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetImageTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetImageTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetImageTypeCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the image type";
+    return "Get the image type";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProviderCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProviderCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetProviderCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the provider";
+    return "Get the provider";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProviderTypeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProviderTypeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,11 @@ public class GetProviderTypeCommand implements Command {
 
   @Override
   public String getPattern() {
-    return String.format("get providertype <%s>", PROVIDER_TYPE_ID);
+    return String.format("get provider type <%s>", PROVIDER_TYPE_ID);
   }
 
   @Override
   public String getDescription() {
-    return "Get provider type";
+    return "Get the provider type by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProvisionerCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetProvisionerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetProvisionerCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the provisioner";
+    return "Get the provisioner by id";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetServiceCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetServiceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetServiceCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the service";
+    return "Get the service";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetTenantCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/GetTenantCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class GetTenantCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Gets the tenant";
+    return "Get the tenant";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAllAutomatorTypesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAllAutomatorTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,11 @@ public class ListAllAutomatorTypesCommand implements Command {
 
   @Override
   public String getPattern() {
-    return String.format("list all automatortypes");
+    return String.format("list automator types");
   }
 
   @Override
   public String getDescription() {
-    return "Lists all automator types";
+    return "List all automator types";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAllProviderTypesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAllProviderTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,12 +43,12 @@ public class ListAllProviderTypesCommand implements Command {
 
   @Override
   public String getPattern() {
-    return String.format("list all providertypes");
+    return String.format("list provider types");
   }
 
   @Override
   public String getDescription() {
-    return "Lists all provider types";
+    return "List all provider types";
   }
 
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAutomatorTypeResourcesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListAutomatorTypeResourcesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,6 @@ public class ListAutomatorTypeResourcesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists automator type resources.";
+    return "List a specific type of automator type resources";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClusterServicesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClusterServicesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ public class ListClusterServicesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all cluster services";
+    return "List all cluster services";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClusterTemplatesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClusterTemplatesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListClusterTemplatesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all cluster templates";
+    return "List all templates";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClustersCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListClustersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListClustersCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all clusters";
+    return "List all clusters";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListHardwareTypesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListHardwareTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListHardwareTypesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all cluster hardware types";
+    return "List all hardware types";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListImageTypesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListImageTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListImageTypesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all image types";
+    return "List all image types";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProviderTypeResourcesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProviderTypeResourcesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,6 @@ public class ListProviderTypeResourcesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists provider type resources.";
+    return "List a specific type of provider type resources";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProvidersCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProvidersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,6 @@ public class ListProvidersCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all providers";
+    return "List all providers";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProvisionersCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListProvisionersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ private final ProvisionerClient provisionerClient;
 
   @Override
   public String getDescription() {
-    return "Lists all provisioners";
+    return "List all provisioners";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListServicesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListServicesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListServicesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all services";
+    return "List all services";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListTenantsCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/ListTenantsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class ListTenantsCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Lists all tenants";
+    return "List all tenants";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/RecallProviderTypeResourcesCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/RecallProviderTypeResourcesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,6 @@ public class RecallProviderTypeResourcesCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Recall a specific version of a provider type resource.";
+    return "Recall a specific version of a provider type resource";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/RestartServiceOnClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/RestartServiceOnClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,6 @@ public class RestartServiceOnClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Restarts service on cluster";
+    return "Restart a service on a cluster";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/SetClusterConfigCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/SetClusterConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,6 @@ public class SetClusterConfigCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Sets the cluster config";
+    return "Set the cluster config";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/SetClusterExpireTimeCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/SetClusterExpireTimeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,6 @@ public class SetClusterExpireTimeCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Sets the cluster expire time";
+    return "Set the cluster expire time";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/StartServiceOnClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/StartServiceOnClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,6 @@ public class StartServiceOnClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Starts service on cluster";
+    return "Start a service on a cluster";
   }
 }

--- a/coopr-cli/src/main/java/co/cask/coopr/shell/command/StopServiceOnClusterCommand.java
+++ b/coopr-cli/src/main/java/co/cask/coopr/shell/command/StopServiceOnClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,6 @@ public class StopServiceOnClusterCommand implements Command {
 
   @Override
   public String getDescription() {
-    return "Stops service on cluster";
+    return "Stop a service on a cluster";
   }
 }

--- a/coopr-cli/src/test/java/co/cask/coopr/shell/command/GetAutomatorTypeCommandTest.java
+++ b/coopr-cli/src/test/java/co/cask/coopr/shell/command/GetAutomatorTypeCommandTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 public class GetAutomatorTypeCommandTest extends AbstractTest {
 
   private static final String INPUT =
-    String.format("get automatortype %s", TEST_PLUGIN_TYPE);
+    String.format("get automator type %s", TEST_PLUGIN_TYPE);
 
   @Test
   public void testExecute() throws Exception {

--- a/coopr-cli/src/test/java/co/cask/coopr/shell/command/GetProviderTypeCommandTest.java
+++ b/coopr-cli/src/test/java/co/cask/coopr/shell/command/GetProviderTypeCommandTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 public class GetProviderTypeCommandTest extends AbstractTest {
 
   private static final String INPUT =
-    String.format("get providertype %s", TEST_PLUGIN_TYPE);
+    String.format("get provider type %s", TEST_PLUGIN_TYPE);
 
   @Test
   public void testExecute() throws Exception {

--- a/coopr-cli/src/test/java/co/cask/coopr/shell/command/ListAllAutomatorTypesCommandTest.java
+++ b/coopr-cli/src/test/java/co/cask/coopr/shell/command/ListAllAutomatorTypesCommandTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 public class ListAllAutomatorTypesCommandTest extends AbstractTest {
 
   private static final String INPUT =
-    String.format("list all automatortypes");
+    String.format("list automator types");
 
   @Test
   public void testExecute() throws Exception {

--- a/coopr-cli/src/test/java/co/cask/coopr/shell/command/ListAllProviderTypesCommandTest.java
+++ b/coopr-cli/src/test/java/co/cask/coopr/shell/command/ListAllProviderTypesCommandTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 public class ListAllProviderTypesCommandTest extends AbstractTest {
 
   private static final String INPUT =
-    String.format("list all providertypes");
+    String.format("list provider types");
 
   @Test
   public void testExecute() throws Exception {


### PR DESCRIPTION
@awholegunch I have updated descriptions of the commands as you mentioned in the ticket comment.

Please see current help output below:

```
coopr (http://localhost:55054)> help 
COOPR_HOST=localhost
COOPR_USER=admin
COOPR_TENANT=superadmin

Available commands:
add
  * add services <services> on cluster <cluster-id>: Add one or more services to a cluster
connect
  * connect to <host> as <user> <tenant> [using port <port>] [with ssl <enabled/disabled>]: Connect to a Coopr instance
create
  * create cluster <name> with template <template> of size <size> [using settings <settings>]: Create a cluster
delete
  * delete cluster <cluster-id> [with provider fields <provider-fields>]: Delete a cluster
  * delete hardware type <name>: Delete a hardware type
  * delete image type <name>: Delete an image type
  * delete provider <name>: Delete a provider
  * delete resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Delete a specific version of an automator type resource
  * delete resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Delete a specific version of a provider type resource
  * delete service <name>: Delete a service
  * delete template <name>: Delete a cluster template
  * delete tenant <name>: Delete a tenant
exit
  * exit: Exits the command line interface
get
  * get automator type <automator-id>: Get the automator type by id
  * get cluster <cluster-id>: Get the cluster by id
  * get cluster-config <cluster-id>: Get the cluster config by id
  * get cluster-status <cluster-id>: Get the cluster status by id
  * get hardware type <name>: Get the hardware type
  * get image type <name>: Get the image type
  * get provider <name>: Get the provider
  * get provider type <provider-id>: Get the provider type by id
  * get provisioner <provisioner-id>: Get the provisioner by id
  * get service <name>: Get the service
  * get template <name>: Get the cluster template
  * get tenant <name>: Get the tenant
help
  * help [<command>]: Prints usage information or description of a command
list
  * list automator types: List all automator types
  * list clusters: List all clusters
  * list hardware types: List all hardware types
  * list image types: List all image types
  * list provider types: List all provider types
  * list providers: List all providers
  * list provisioners: List all provisioners
  * list resources from automator <automator-id> of type <resource-type> [and status <status>]:
      List a specific type of automator type resources
  * list resources from provider <provider-id> of type <resource-type> [and status <status>]:
      List a specific type of provider type resources
  * list services: List all services
  * list services <cluster-id>: List all cluster services
  * list templates: List all templates
  * list tenants: List all tenants
quit
  * quit: Quits the command line interface
recall
  * recall resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Recall a specific version of an automator type resource
  * recall resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Recall a specific version of a provider type resource
restart
  * restart service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]:
      Restart a service on a cluster
set
  * set config <cluster-config> for cluster <cluster-id>: Set the cluster config
  * set expire time <expire-time> for cluster <cluster-id>: Set the cluster expire time
stage
  * stage resource from automator <automator-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Stage a specific version of an automator type resource
  * stage resource from provider <provider-id> of type <resource-type> and name <resource-name> and version <resource-version>:
      Stage a specific version of a provider type resource
start
  * start service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]: Start a service on a cluster
stop
  * stop service <service-id> on cluster <cluster-id> [with provider fields <provider-fields>]: Stop a service on a cluster
sync
  * sync cluster template <cluster-id>: Synchronize the cluster template
  * sync resources: Synchronize resources
```
