### PR TITLE
Only run sudoers code when /etc/sudoers exists

### DIFF
--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -136,8 +136,15 @@ class FogProviderDigitalOcean < Provider
       # login with pseudotty and turn off sudo requiretty option
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials} and pseudotty"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        sudoers = true
+        begin
+          ssh_exec!(ssh, 'test -e /etc/sudoers', 'Checking for /etc/sudoers')
+        rescue CommandExecutionError
+          log.debug 'No /etc/sudoers file present'
+          sudoers = false
+        end
         cmd = "#{sudo} sed -i -e '/^Defaults[[:space:]]*requiretty/ s/^/#/' /etc/sudoers"
-        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true)
+        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true) if sudoers
       end
 
       # Validate connectivity

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -158,8 +158,15 @@ class FogProviderGoogle < Provider
       # login with pseudotty and turn off sudo requiretty option
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials} and pseudotty"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        sudoers = true
+        begin
+          ssh_exec!(ssh, 'test -e /etc/sudoers', 'Checking for /etc/sudoers')
+        rescue CommandExecutionError
+          log.debug 'No /etc/sudoers file present'
+          sudoers = false
+        end
         cmd = "#{sudo} sed -i -e '/^Defaults[[:space:]]*requiretty/ s/^/#/' /etc/sudoers"
-        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true)
+        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true) if sudoers
       end
 
       # Validate connectivity

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -112,8 +112,15 @@ class FogProviderJoyent < Provider
       # login with pseudotty and turn off sudo requiretty option
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials} and pseudotty"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        sudoers = true
+        begin
+          ssh_exec!(ssh, 'test -e /etc/sudoers', 'Checking for /etc/sudoers')
+        rescue CommandExecutionError
+          log.debug 'No /etc/sudoers file present'
+          sudoers = false
+        end
         cmd = "#{sudo} sed -i -e '/^Defaults[[:space:]]*requiretty/ s/^/#/' /etc/sudoers"
-        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true)
+        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true) if sudoers
       end
 
       # Validate connectivity

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -130,8 +130,15 @@ class FogProviderOpenstack < Provider
       # login with pseudotty and turn off sudo requiretty option
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials} and pseudotty"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        sudoers = true
+        begin
+          ssh_exec!(ssh, 'test -e /etc/sudoers', 'Checking for /etc/sudoers')
+        rescue CommandExecutionError
+          log.debug 'No /etc/sudoers file present'
+          sudoers = false
+        end
         cmd = "#{sudo} sed -i -e '/^Defaults[[:space:]]*requiretty/ s/^/#/' /etc/sudoers"
-        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true)
+        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true) if sudoers
       end
 
       # Validate connectivity

--- a/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/coopr-provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -117,8 +117,15 @@ class FogProviderRackspace < Provider
       # login with pseudotty and turn off sudo requiretty option
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials} and pseudotty"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        sudoers = true
+        begin
+          ssh_exec!(ssh, 'test -e /etc/sudoers', 'Checking for /etc/sudoers')
+        rescue CommandExecutionError
+          log.debug 'No /etc/sudoers file present'
+          sudoers = false
+        end
         cmd = "#{sudo} sed -i -e '/^Defaults[[:space:]]*requiretty/ s/^/#/' /etc/sudoers"
-        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true)
+        ssh_exec!(ssh, cmd, 'Disabling requiretty via pseudotty session', true) if sudoers
       end
 
       # Validate connectivity and Mount data disk


### PR DESCRIPTION
There's no `/etc/sudoers` on CoreOS, so we have to make sure it exists before we try to sed it.
