### PR TITLE
Update coopr-templates ref for issues 19-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Unreleased
 - Provisioner worker - Info log on CREATE, DELETE events for provisioner added COOPR-539 ( Issues: #873 )
 - Standalone - Dockerfile for coopr-standalone ( Issues: #874 )
 - Update coopr-provisioner submodule ( Issues: #880 #883 caskdata/coopr-provisioner#1 caskdata/coopr-provisioner#2 caskdata/coopr-provisioner#3 )
+- Update coopr-templates submodule ( Issues: # caskdata/coopr-templates#19 caskdata/coopr-templates#20 caskdata/coopr-templates#21 caskdata/coopr-templates#22 )
 
 v0.9.8 (09/26/14)
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ Unreleased
 - Provisioner worker - Info log on CREATE, DELETE events for provisioner added COOPR-539 ( Issues: #873 )
 - Standalone - Dockerfile for coopr-standalone ( Issues: #874 )
 - Update coopr-provisioner submodule ( Issues: #880 #883 caskdata/coopr-provisioner#1 caskdata/coopr-provisioner#2 caskdata/coopr-provisioner#3 )
-- Update coopr-templates submodule ( Issues: # caskdata/coopr-templates#19 caskdata/coopr-templates#20 caskdata/coopr-templates#21 caskdata/coopr-templates#22 )
+- Update coopr-templates submodule ( Issues: #896 caskdata/coopr-templates#19 caskdata/coopr-templates#20 caskdata/coopr-templates#21 caskdata/coopr-templates#22 )
 
 v0.9.8 (09/26/14)
 -----------------


### PR DESCRIPTION
This imports fixes for:
- [x] caskdata/coopr-templates#19
- [x] caskdata/coopr-templates#20
- [x] caskdata/coopr-templates#21
- [x] caskdata/coopr-templates#22
