### PR TITLE
COOPR-585 Better Coopr Server memory allocation

### DIFF
--- a/coopr-server/bin/server.sh
+++ b/coopr-server/bin/server.sh
@@ -21,9 +21,9 @@ export COOPR_HOME=${COOPR_HOME:-/opt/coopr}
 ### TODO: make this suck less (COOPR-545)
 [ -d /opt/coopr ] && DEFAULT_JVM_OPTS="-Xmx3072m" || DEFAULT_JVM_OPTS="-Xmx1024m"
 
-die ( ) { echo; echo "ERROR: ${*}"; echo; exit 1; }
+die() { echo; echo "ERROR: ${*}"; echo; exit 1; }
 
-splitJvmOpts ( ) { JVM_OPTS=("$@"); }
+splitJvmOpts() { JVM_OPTS=("$@"); }
 
 APP_NAME="coopr-server"
 COOPR_SERVER_CONF=${COOPR_SERVER_CONF:-/etc/coopr/conf}
@@ -64,7 +64,7 @@ check_before_start() {
   fi
 }
 
-start ( ) {
+start() {
   eval splitJvmOpts ${DEFAULT_JVM_OPTS} ${COOPR_JAVA_OPTS}
   check_before_start
 
@@ -74,7 +74,7 @@ start ( ) {
   echo ${!} > ${pid}
 }
 
-stop ( ) {
+stop() {
   echo -n "Stopping Server ..."
   if [ -f ${pid} ] ; then
     pidToKill=`cat ${pid}`

--- a/coopr-server/bin/server.sh
+++ b/coopr-server/bin/server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2012-2014 Cask Data, Inc.
+# Copyright © 2012-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@
 export COOPR_LOG_DIR=${COOPR_LOG_DIR:-/var/log/coopr}
 export COOPR_HOME=${COOPR_HOME:-/opt/coopr}
 
-### TODO: make this suck less (COOPR-545)
-[ -d /opt/coopr ] && DEFAULT_JVM_OPTS="-Xmx3072m" || DEFAULT_JVM_OPTS="-Xmx1024m"
+DEFAULT_JVM_OPTS=${DEFAULT_JVM_OPTS:--Xmx3072m}
 
 die() { echo; echo "ERROR: ${*}"; echo; exit 1; }
 

--- a/coopr-standalone/bin/coopr.sh
+++ b/coopr-standalone/bin/coopr.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
-
-##############################################################################
-##
-##  Coopr Standalone start up script for *NIX and Mac
-##
-##############################################################################
+#
+# Copyright © 2012-2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Server environment
 # Add default JVM options here. You can also use JAVA_OPTS and COOPR_JAVA_OPTS to pass JVM options to this script.
+export DEFAULT_JVM_OPTS="-Xmx1024m"
 export COOPR_JAVA_OPTS="-XX:+UseConcMarkSweepGC -Dderby.stream.error.field=DerbyUtil.DEV_NULL"
 
 # UI environment


### PR DESCRIPTION
Defaulting this is a better solution than detecting if `/opt/coopr` exists.
