### PR TITLE
COOPR-681 CLI should provide usage when given invalid command

### DIFF
--- a/coopr-cli/pom.xml
+++ b/coopr-cli/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>co.cask.common</groupId>
       <artifactId>common-cli</artifactId>
-      <version>0.1.0</version>
+      <version>0.4.0</version>
     </dependency>
     <dependency>
       <groupId>jline</groupId>


### PR DESCRIPTION
```
coopr (http://localhost:55054)> invalidcommand
Invalid command: 'invalidcommand' - Enter 'help' for a list of commands
```
