### PR TITLE
update standalone instructions to include deep_merge gem

### DIFF
--- a/coopr-standalone/README.md
+++ b/coopr-standalone/README.md
@@ -18,6 +18,7 @@ sudo gem install sinatra --version 1.4.5
 sudo gem install thin --version 1.6.2
 sudo gem install rest_client --version 1.7.3
 sudo gem install google-api-client --version 0.7.1
+sudo gem install deep_merge --version 1.0.1
 ```
 
 ## Start


### PR DESCRIPTION
- [x] standalone README update needed for https://github.com/caskdata/coopr-provisioner/pull/32
- [ ] For a subsequent PR, I think we can actually just use bundler now for standalone.
