### PR TITLE
move standalone data dir

### DIFF
--- a/coopr-standalone/provisioner/conf/provisioner-site.xml
+++ b/coopr-standalone/provisioner/conf/provisioner-site.xml
@@ -10,7 +10,7 @@
   </property>
   <property>
     <name>provisioner.data.dir</name>
-    <value>COOPR_DATA_DIR</value>
+    <value>COOPR_DATA_DIR/provisioner/data</value>
     <description>Provisioner storage directory for plugin data resources</description>
   </property>
   <property>


### PR DESCRIPTION
fixes https://issues.cask.co/browse/COOPR-700

Standalone's data directory was out of place.  This puts it in the logical place (alongside work.dir): `${STANDALONE_ROOT}/data/provisioner/data`
