### PR TITLE
COOPR-719 Limit select to correct tenant

### DIFF
--- a/coopr-server/src/main/java/co/cask/coopr/store/entity/BaseSQLEntityStoreView.java
+++ b/coopr-server/src/main/java/co/cask/coopr/store/entity/BaseSQLEntityStoreView.java
@@ -181,6 +181,7 @@ public abstract class BaseSQLEntityStoreView extends BaseEntityStoreView {
     queryBuilder.append(" INNER JOIN(");
     queryBuilder.append("   SELECT name, MAX(version) version");
     queryBuilder.append("   FROM ").append(entityType.getTableName());
+    queryBuilder.append("   WHERE tenant_id=?");
     queryBuilder.append("   GROUP BY name");
     queryBuilder.append(" ) ss on t.name = ss.name AND t.version = ss.version");
     queryBuilder.append(" WHERE t.tenant_id=?");
@@ -193,6 +194,7 @@ public abstract class BaseSQLEntityStoreView extends BaseEntityStoreView {
 
     PreparedStatement statement = conn.prepareStatement(queryString);
     statement.setString(1, tenantId);
+    statement.setString(2, tenantId);
     return statement;
   }
 }


### PR DESCRIPTION
The previous behavior did not limit the searches to a single tenant. As such, it's possible to return an empty set.

Before:

```
mysql> SELECT t.provider, t.name, t.version FROM providers t INNER JOIN(SELECT name, MAX(version) version FROM providers GROUP BY name) ss ON t.name = ss.name AND t.version = ss.version WHERE t.tenant_id='superadmin';
Empty set (0.00 sec)
```

After:

```
mysql> SELECT t.provider, t.name, t.version FROM providers t INNER JOIN(SELECT name, MAX(version) version FROM providers where tenant_id='superadmin' GROUP BY name) ss ON t.name = ss.name AND t.version = ss.version WHERE t.tenant_id='superadmin';

<snip>
8 rows in set (0.00 sec)
```
