### PR TITLE
Update coopr-provisioner ref and make appropriate README changes

### DIFF
--- a/coopr-standalone/README.md
+++ b/coopr-standalone/README.md
@@ -12,13 +12,12 @@ mvn clean package assembly:single -DskipTests
 ```
 
 ## Install
+
+This will install the appropriate Ruby Gems on the system.
 ```
-sudo gem install fog --version 1.26.0
-sudo gem install sinatra --version 1.4.5
-sudo gem install thin --version 1.6.2
-sudo gem install rest_client --version 1.7.3
-sudo gem install google-api-client --version 0.7.1
-sudo gem install deep_merge --version 1.0.1
+sudo gem install bundler
+cd coopr-provisioner
+bundle install
 ```
 
 ## Start
@@ -38,7 +37,3 @@ Once Cask Coopr is running, follow the instructions in the quickstart guide at
 http://docs.cask.co/coopr/current/en/guide/quickstart/index.html#getting-started.
 
 It contains step by step instructions for creating a Hadoop cluster with different providers.
-
-## Known Issues
-GCE does not offer an ubuntu image, so the Google provider included here has no corresponding
-ubuntu image type. If you require one, you will have to add your own.


### PR DESCRIPTION
Commit ref is latest release/0.9.9 branch from coopr-provisioner repository. Updated standalone README to use bundler and remove inaccurate known issues.
