### PR TITLE
Start blank, rather than assume template named base exists

### DIFF
--- a/coopr-ui/app/features/clusters/controllers/form-ctrl.js
+++ b/coopr-ui/app/features/clusters/controllers/form-ctrl.js
@@ -9,7 +9,7 @@ function ($scope, $state, $q, $alert, CrudFormBase, myApi, caskFocusManager, myH
 
   var id = $state.params.id;
 
-  $scope.model = new myApi.Cluster({id:id, clusterTemplate:'base', numMachines:1});
+  $scope.model = new myApi.Cluster({id:id, clusterTemplate:'', numMachines:1});
 
   $scope.showAdvanced = false;
   $scope.showConfig = !!id;


### PR DESCRIPTION
This prevents a user from having to remove services from the list and removes the requirement that a template named "base" exists on the server.
