### PR TITLE
Update Dockerfile to support latest Coopr 0.9.9 repack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends openjdk-6-jdk && \
     apt-get install -y \
       build-essential \
+      zlib1g-dev \
       curl \
       git \
       maven \
@@ -34,11 +35,15 @@ RUN apt-get update && \
       ruby1.9.3 \
       unzip
 
-RUN gem install fog --version 1.26.0 --no-rdoc --no-ri && \
+RUN gem install fog --version 1.36.0 --no-rdoc --no-ri && \
     gem install sinatra --version 1.4.5 --no-rdoc --no-ri && \
     gem install thin --version 1.6.2 --no-rdoc --no-ri && \
     gem install rest_client --version 1.7.3 --no-rdoc --no-ri && \
-    gem install google-api-client --version 0.7.1 --no-rdoc --no-ri
+    gem install google-api-client --version 0.7.1 --no-rdoc --no-ri && \
+    gem install net-ssh --version 2.9.4 --no-rdoc --no-ri && \
+    gem install net-scp --version 1.2.1 --no-rdoc --no-ri && \
+    gem install logger --version 1.2.8 --no-rdoc --no-ri && \
+    gem install deep_merge --version 1.0.1 --no-rdoc --no-ri
  
 # create Software directory
 RUN mkdir /Build /Software
@@ -69,6 +74,7 @@ EXPOSE 55054
 # Clean UP (reduce space usage of container as much as possible)
 RUN apt-get purge -y \
       build-essential \
+      zlib1g-dev \
       git \
       maven \
       unzip && \


### PR DESCRIPTION
Attempting to rebuild the Docker image for caskdata/coopr-standalone resulted in a failure trying to install Gems (nokogiri failed due to missing zlib headers)... fixing that resulted in a Coopr Provisioner with missing Gems (net-scp)... Resolving that led me down a path of setting a couple Gem versions and also pulling in missing dependencies, like `deep_merge`...
